### PR TITLE
Add logic to manage the scale testing benchmark

### DIFF
--- a/scripts/scale-test/benchmarks/benchmark.py
+++ b/scripts/scale-test/benchmarks/benchmark.py
@@ -1,0 +1,57 @@
+import logging
+from typing import List, Optional
+
+from benchmarks.cluster import Microk8sCluster
+from benchmarks.workload import Workload
+
+
+class Benchmark:
+    """
+    Manages runtime of a benchmark experiment on top of a Microk8s cluster.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        cluster: Microk8sCluster,
+        required_addons: Optional[List[str]] = None,
+    ):
+        self.name = name
+        self.required_addons = required_addons or []
+        self.cluster = cluster
+        self.workloads: List[Workload] = []
+
+    def register_workloads(self, workloads):
+        self.workloads.extend(workloads)
+
+    def start(self):
+        logging.info(f"Started benchmark: {self.name}")
+        n_workloads = len(self.workloads)
+
+        for index, workload in enumerate(self.workloads):
+            workload.apply()
+            workload.wait()
+
+            is_last_workload = index == n_workloads - 1
+            if n_workloads > 1 and not is_last_workload:
+                self.cluster.reset()
+
+    def bootstrap(self):
+        logging.info("Bootstrapping cluster")
+        if len(self.required_addons) > 0:
+            self.cluster.enable(self.required_addons)
+
+    def teardown(self):
+        logging.info("Cluster teardown")
+        self.cluster.reset()
+        if len(self.required_addons) > 0:
+            self.cluster.disable(self.required_addons)
+
+    def run(self):
+        try:
+            self.bootstrap()
+            self.start()
+        except KeyboardInterrupt:
+            logging.info("Experiment cancelled! Tearing down cluster...")
+        finally:
+            self.teardown()

--- a/scripts/scale-test/benchmarks/clients/kubectl.py
+++ b/scripts/scale-test/benchmarks/clients/kubectl.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 KUBECTL = "/usr/bin/kubectl"
 
@@ -12,5 +13,16 @@ def _kubectl(*args):
     return subprocess.run(cmd, capture_output=True)
 
 
-def apply(yaml: Path) -> None:
-    _kubectl("apply", "-f", yaml).check_returncode()
+def apply(yaml: Path, namespace: Optional[str] = None) -> None:
+    command = ["apply", "-f", yaml]
+    if namespace is not None:
+        command.append(f"--namespace={namespace}")
+    return _kubectl(*command).check_returncode()
+
+
+def create(type: str, name: str):
+    return _kubectl("create", type, name)
+
+
+def delete(type: str, name: str):
+    return _kubectl("delete", type, name)

--- a/scripts/scale-test/benchmarks/clients/kubectl.py
+++ b/scripts/scale-test/benchmarks/clients/kubectl.py
@@ -1,0 +1,16 @@
+import logging
+import subprocess
+from pathlib import Path
+
+KUBECTL = "/usr/bin/kubectl"
+
+
+def _kubectl(*args):
+    cmd = [KUBECTL]
+    cmd.extend(args)
+    logging.debug(f"subprocess.run {';'.join(cmd)}")
+    return subprocess.run(cmd, capture_output=True)
+
+
+def apply(yaml: Path) -> None:
+    _kubectl("apply", "-f", yaml).check_returncode()

--- a/scripts/scale-test/benchmarks/cluster.py
+++ b/scripts/scale-test/benchmarks/cluster.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 
-from benchmarks.clients import juju
+from benchmarks.clients import juju, kubectl
 from benchmarks.models import ClusterInfo, Unit
 
 
@@ -38,9 +38,13 @@ class Microk8sCluster:
     def run_in_master_node(self, command: str):
         return self.run_in_unit(self.get_master_node(), command)
 
-    def reset(self):
-        logging.info("Resetting microk8s cluster")
-        return self.run_in_master_node("microk8s reset")
+    def create_namespace(self, name: str):
+        logging.info(f"Creating {name} namespace")
+        return kubectl.create("ns", name)
+
+    def delete_namespace(self, name: str):
+        logging.info(f"Deleting {name} namespace")
+        return kubectl.delete("ns", name)
 
     def enable(self, addons: List[str]):
         addons = " ".join(addons)

--- a/scripts/scale-test/benchmarks/cluster.py
+++ b/scripts/scale-test/benchmarks/cluster.py
@@ -1,0 +1,53 @@
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+from benchmarks.clients import juju
+from benchmarks.models import ClusterInfo, Unit
+
+
+class Microk8sCluster:
+    """
+    Handles interactions to the Microk8s cluster
+    """
+
+    def __init__(self, info: Optional[ClusterInfo] = None):
+        self.info = info
+
+    @classmethod
+    def from_file(klass, cluster_file: Path):
+        with open(cluster_file, mode="r") as f:
+            info = ClusterInfo.from_json(json.loads(f.read()))
+            return klass(info)
+
+    def get_master_node(self) -> Unit:
+        return self.info.master
+
+    def run_in_unit(self, unit: Unit, command: str):
+        resp = juju.run(command, unit=unit.name)
+        try:
+            resp.check_returncode()
+            return resp
+        except subprocess.CalledProcessError:
+            stderr = resp.stderr.decode().strip()
+            logging.error(f"Error running {command} on {unit.name}: {stderr}")
+            raise
+
+    def run_in_master_node(self, command: str):
+        return self.run_in_unit(self.get_master_node(), command)
+
+    def reset(self):
+        logging.info("Resetting microk8s cluster")
+        return self.run_in_master_node("microk8s reset")
+
+    def enable(self, addons: List[str]):
+        addons = " ".join(addons)
+        logging.info(f"Enabling addons: {addons}")
+        return self.run_in_master_node(f"microk8s enable {addons}")
+
+    def disable(self, addons: List[str]):
+        addons = " ".join(addons)
+        logging.info(f"Disabling addon: {addons}")
+        return self.run_in_master_node(f"microk8s disable {addons}")

--- a/scripts/scale-test/benchmarks/models.py
+++ b/scripts/scale-test/benchmarks/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List
 
 
 @dataclass
@@ -13,7 +13,7 @@ class Unit:
 
 
 @dataclass
-class Cluster:
+class ClusterInfo:
     master: Unit
     workers: List[Unit]
     control_plane: List[Unit]
@@ -24,6 +24,14 @@ class Cluster:
             "workers": [u.to_dict() for u in self.workers],
             "control_plane": [u.to_dict() for u in self.control_plane],
         }
+
+    @classmethod
+    def from_json(klass, data: Dict[str, str]) -> "ClusterInfo":
+        return klass(
+            master=Unit(**data["master"]),
+            control_plane=[Unit(**cp) for cp in data["control_plane"]],
+            workers=[Unit(**worker) for worker in data["workers"]],
+        )
 
 
 @dataclass

--- a/scripts/scale-test/benchmarks/workload.py
+++ b/scripts/scale-test/benchmarks/workload.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from pathlib import Path
+from typing import Optional
 
 from benchmarks.utils import pp_time
 
@@ -16,8 +17,8 @@ class Workload:
     def __str__(self) -> str:
         return f"Workload[{self.yaml}]"
 
-    def apply(self) -> None:
-        kubectl.apply(self.yaml)
+    def apply(self, namespace: Optional[str] = None) -> None:
+        kubectl.apply(self.yaml, namespace=namespace)
 
     def wait(self) -> None:
         start = time.time()

--- a/scripts/scale-test/benchmarks/workload.py
+++ b/scripts/scale-test/benchmarks/workload.py
@@ -1,0 +1,29 @@
+import logging
+import time
+from pathlib import Path
+
+from benchmarks.utils import pp_time
+
+from .clients import kubectl
+
+
+class Workload:
+    def __init__(self, yaml: Path, duration: int, poll_period: int = 5):
+        self.yaml = yaml
+        self.duration = duration
+        self.poll_period = poll_period
+
+    def __str__(self) -> str:
+        return f"Workload[{self.yaml}]"
+
+    def apply(self) -> None:
+        kubectl.apply(self.yaml)
+
+    def wait(self) -> None:
+        start = time.time()
+        while True:
+            remaining = int(self.duration - (time.time() - start))
+            if remaining <= 0:
+                break
+            logging.info(f"Waiting for {self}... {pp_time(remaining)} left")
+            time.sleep(self.poll_period)

--- a/scripts/scale-test/scale_test.py
+++ b/scripts/scale-test/scale_test.py
@@ -28,11 +28,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main():
-    args = parse_args()
+def configure_logging(args: argparse.Namespace) -> None:
     if args.debug:
         logging.root.setLevel(logging.DEBUG)
 
+
+def main():
+    args = parse_args()
+    configure_logging(args)
     cluster = Microk8sCluster.from_file(Path(args.cluster_file))
     scaletest = Benchmark(
         "scale_testing",

--- a/scripts/scale-test/scale_test.py
+++ b/scripts/scale-test/scale_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+import argparse
+import logging
+from pathlib import Path
+
+from benchmarks.benchmark import Benchmark
+from benchmarks.cluster import Microk8sCluster
+from benchmarks.workload import Workload
+
+MINUTE = 60
+WORKLOAD_TIME = 2 * MINUTE
+
+LOG_FORMAT = "[%(asctime)s] [%(levelname)8s] --- %(message)s"
+LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
+logging.basicConfig(format=LOG_FORMAT, level=logging.INFO, datefmt=LOG_DATEFMT)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("Scale test benchmark", description="Run")
+    parser.add_argument(
+        "-c",
+        "--cluster-file",
+        required=True,
+        help="Path of the json file with the details of the cluster where to run the experiment",
+    )
+    parser.add_argument("--debug", action="store_true", help="Increase log verbosity")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.debug:
+        logging.root.setLevel(logging.DEBUG)
+
+    cluster = Microk8sCluster.from_file(Path(args.cluster_file))
+    scaletest = Benchmark(
+        "scale_testing",
+        cluster=cluster,
+        required_addons=["dns", "hostpath-storage"],  # , "prometheus"],
+    )
+    scaletest.register_workloads(
+        [
+            Workload("workloads/stateless.yaml", duration=WORKLOAD_TIME),
+            Workload("workloads/stateful.yaml", duration=WORKLOAD_TIME),
+            Workload("workloads/ingress.yaml", duration=WORKLOAD_TIME),
+        ]
+    )
+    scaletest.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scale-test/tests/integration/conftest.py
+++ b/scripts/scale-test/tests/integration/conftest.py
@@ -1,0 +1,37 @@
+import json
+import subprocess
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from benchmarks.clients import juju
+from benchmarks.models import ClusterInfo, Unit
+
+TEST_JUJU_STATUS_OUTPUT = b"""{"model":{"name":"microk8s","type":"iaas","controller":"mk8s-testing-controller","cloud":"mk8s-testing","region":"Boston","version":"2.9.29","model-status":{"current":"available","since":"26 May 2022 12:58:26+02:00"},"sla":"unsupported"},"machines":{"0":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-0","dns-name":"10.246.154.108","ip-addresses":["10.246.154.108"],"instance-id":"juju-c6c89a-0","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.108"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"},"1":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-1","dns-name":"10.246.154.111","ip-addresses":["10.246.154.111"],"instance-id":"juju-c6c89a-1","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.111"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"}},"applications":{"microk8s-node":{"charm":"ubuntu","series":"focal","os":"ubuntu","charm-origin":"charmhub","charm-name":"ubuntu","charm-rev":19,"charm-channel":"stable","exposed":false,"application-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"units":{"microk8s-node/0":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":true,"machine":"0","public-address":"10.246.154.108"},"microk8s-node/1":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":false,"machine":"1","public-address":"10.246.154.111"}},"version":"20.04"}},"storage":{},"controller":{"timestamp":"13:03:13+02:00"}}"""  # noqa
+
+
+@pytest.fixture()
+def juju_status_mock():
+    with patch.object(juju, "status") as _status:
+        _status().stdout = TEST_JUJU_STATUS_OUTPUT
+        yield _status
+
+
+@pytest.fixture()
+def subprocess_run_mock():
+    with patch.object(subprocess, "run") as _run:
+        yield _run
+
+
+@pytest.fixture()
+def cluster_json():
+    f = tempfile.NamedTemporaryFile(delete=False)
+    master = Unit(name="name", ip="ip", instance_id="id")
+    cluster = ClusterInfo(master=master, control_plane=[master], workers=[])
+    f.write(json.dumps(cluster.to_dict()).encode())
+    f.file.flush()
+
+    yield f.name
+
+    f.close()

--- a/scripts/scale-test/tests/integration/test_scale_test.py
+++ b/scripts/scale-test/tests/integration/test_scale_test.py
@@ -1,17 +1,21 @@
+import json
 import subprocess
 import sys
+import tempfile
 from unittest.mock import patch
 
 import pytest
 
-import setup_cluster
+import scale_test
+from benchmarks.clients import juju
+from benchmarks.models import ClusterInfo, Unit
 
 TEST_JUJU_STATUS_OUTPUT = b"""{"model":{"name":"microk8s","type":"iaas","controller":"mk8s-testing-controller","cloud":"mk8s-testing","region":"Boston","version":"2.9.29","model-status":{"current":"available","since":"26 May 2022 12:58:26+02:00"},"sla":"unsupported"},"machines":{"0":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-0","dns-name":"10.246.154.108","ip-addresses":["10.246.154.108"],"instance-id":"juju-c6c89a-0","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.108"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"},"1":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-1","dns-name":"10.246.154.111","ip-addresses":["10.246.154.111"],"instance-id":"juju-c6c89a-1","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.111"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"}},"applications":{"microk8s-node":{"charm":"ubuntu","series":"focal","os":"ubuntu","charm-origin":"charmhub","charm-name":"ubuntu","charm-rev":19,"charm-channel":"stable","exposed":false,"application-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"units":{"microk8s-node/0":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":true,"machine":"0","public-address":"10.246.154.108"},"microk8s-node/1":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":false,"machine":"1","public-address":"10.246.154.111"}},"version":"20.04"}},"storage":{},"controller":{"timestamp":"13:03:13+02:00"}}"""  # noqa
 
 
 @pytest.fixture()
 def juju_status_mock():
-    with patch("setup_cluster.juju.status") as _status:
+    with patch.object(juju, "status") as _status:
         _status().stdout = TEST_JUJU_STATUS_OUTPUT
         yield _status
 
@@ -22,6 +26,26 @@ def subprocess_run_mock():
         yield _run
 
 
-@patch.object(sys, "argv", ["setup_cluster", "--http-proxy", "http://myproxy"])
-def test_main(juju_status_mock, subprocess_run_mock):
-    setup_cluster.main()
+@pytest.fixture()
+def workload_time():
+    with patch.object(scale_test, "WORKLOAD_TIME", new=1):
+        yield
+
+
+@pytest.fixture()
+def cluster_json():
+    f = tempfile.NamedTemporaryFile(delete=False)
+    master = Unit(name="name", ip="ip", instance_id="id")
+    cluster = ClusterInfo(master=master, control_plane=[master], workers=[])
+    f.write(json.dumps(cluster.to_dict()).encode())
+    f.file.flush()
+
+    yield f.name
+
+    f.close()
+
+
+def test_main(juju_status_mock, subprocess_run_mock, workload_time, cluster_json):
+    with patch.object(sys, "argv", ["scale_testing", "-c", cluster_json]):
+
+        scale_test.main()

--- a/scripts/scale-test/tests/integration/test_scale_test.py
+++ b/scripts/scale-test/tests/integration/test_scale_test.py
@@ -1,29 +1,9 @@
-import json
-import subprocess
 import sys
-import tempfile
 from unittest.mock import patch
 
 import pytest
 
 import scale_test
-from benchmarks.clients import juju
-from benchmarks.models import ClusterInfo, Unit
-
-TEST_JUJU_STATUS_OUTPUT = b"""{"model":{"name":"microk8s","type":"iaas","controller":"mk8s-testing-controller","cloud":"mk8s-testing","region":"Boston","version":"2.9.29","model-status":{"current":"available","since":"26 May 2022 12:58:26+02:00"},"sla":"unsupported"},"machines":{"0":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-0","dns-name":"10.246.154.108","ip-addresses":["10.246.154.108"],"instance-id":"juju-c6c89a-0","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.108"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"},"1":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-1","dns-name":"10.246.154.111","ip-addresses":["10.246.154.111"],"instance-id":"juju-c6c89a-1","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.111"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"}},"applications":{"microk8s-node":{"charm":"ubuntu","series":"focal","os":"ubuntu","charm-origin":"charmhub","charm-name":"ubuntu","charm-rev":19,"charm-channel":"stable","exposed":false,"application-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"units":{"microk8s-node/0":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":true,"machine":"0","public-address":"10.246.154.108"},"microk8s-node/1":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":false,"machine":"1","public-address":"10.246.154.111"}},"version":"20.04"}},"storage":{},"controller":{"timestamp":"13:03:13+02:00"}}"""  # noqa
-
-
-@pytest.fixture()
-def juju_status_mock():
-    with patch.object(juju, "status") as _status:
-        _status().stdout = TEST_JUJU_STATUS_OUTPUT
-        yield _status
-
-
-@pytest.fixture()
-def subprocess_run_mock():
-    with patch.object(subprocess, "run") as _run:
-        yield _run
 
 
 @pytest.fixture()
@@ -32,20 +12,7 @@ def workload_time():
         yield
 
 
-@pytest.fixture()
-def cluster_json():
-    f = tempfile.NamedTemporaryFile(delete=False)
-    master = Unit(name="name", ip="ip", instance_id="id")
-    cluster = ClusterInfo(master=master, control_plane=[master], workers=[])
-    f.write(json.dumps(cluster.to_dict()).encode())
-    f.file.flush()
-
-    yield f.name
-
-    f.close()
-
-
-def test_main(juju_status_mock, subprocess_run_mock, workload_time, cluster_json):
+def test_main(subprocess_run_mock, workload_time, cluster_json):
     with patch.object(sys, "argv", ["scale_testing", "-c", cluster_json]):
 
         scale_test.main()

--- a/scripts/scale-test/tests/integration/test_setup_cluster.py
+++ b/scripts/scale-test/tests/integration/test_setup_cluster.py
@@ -1,25 +1,7 @@
-import subprocess
 import sys
 from unittest.mock import patch
 
-import pytest
-
 import setup_cluster
-
-TEST_JUJU_STATUS_OUTPUT = b"""{"model":{"name":"microk8s","type":"iaas","controller":"mk8s-testing-controller","cloud":"mk8s-testing","region":"Boston","version":"2.9.29","model-status":{"current":"available","since":"26 May 2022 12:58:26+02:00"},"sla":"unsupported"},"machines":{"0":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-0","dns-name":"10.246.154.108","ip-addresses":["10.246.154.108"],"instance-id":"juju-c6c89a-0","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.108"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"},"1":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-1","dns-name":"10.246.154.111","ip-addresses":["10.246.154.111"],"instance-id":"juju-c6c89a-1","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.111"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"}},"applications":{"microk8s-node":{"charm":"ubuntu","series":"focal","os":"ubuntu","charm-origin":"charmhub","charm-name":"ubuntu","charm-rev":19,"charm-channel":"stable","exposed":false,"application-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"units":{"microk8s-node/0":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":true,"machine":"0","public-address":"10.246.154.108"},"microk8s-node/1":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":false,"machine":"1","public-address":"10.246.154.111"}},"version":"20.04"}},"storage":{},"controller":{"timestamp":"13:03:13+02:00"}}"""  # noqa
-
-
-@pytest.fixture()
-def juju_status_mock():
-    with patch("setup_cluster.juju.status") as _status:
-        _status().stdout = TEST_JUJU_STATUS_OUTPUT
-        yield _status
-
-
-@pytest.fixture()
-def subprocess_run_mock():
-    with patch.object(subprocess, "run") as _run:
-        yield _run
 
 
 @patch.object(sys, "argv", ["setup_cluster", "--http-proxy", "http://myproxy"])

--- a/scripts/scale-test/tests/unit/test_benchmark.py
+++ b/scripts/scale-test/tests/unit/test_benchmark.py
@@ -1,0 +1,45 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from benchmarks.benchmark import Benchmark
+
+
+@patch("benchmarks.benchmark.Benchmark.teardown")
+def test_run_calls_teardown_on_graceful_exit(_teardown):
+    bmk = Benchmark("foo", None)
+
+    bmk.run()
+
+    _teardown.assert_called_once()
+
+
+@patch("benchmarks.benchmark.Benchmark.teardown")
+@patch("benchmarks.benchmark.Benchmark.start")
+def test_run_calls_teardown_on_exception(_start, _teardown):
+    bmk = Benchmark("foo", None)
+
+    # Unhandled exception
+    _start.side_effect = Exception()
+    with pytest.raises(Exception):
+        bmk.run()
+
+    _teardown.assert_called_once()
+
+    # Keyboard interrupt
+    _start.side_effect = KeyboardInterrupt()
+    _teardown.reset_mock()
+
+    bmk.run()
+
+    _teardown.assert_called_once()
+
+
+def test_cluster_is_reset_between_workloads():
+    cluster = Mock()
+    bmk = Benchmark("foo", cluster)
+    bmk.register_workloads([Mock(), Mock()])
+
+    bmk.start()
+
+    cluster.reset.assert_called_once()

--- a/scripts/scale-test/tests/unit/test_benchmark.py
+++ b/scripts/scale-test/tests/unit/test_benchmark.py
@@ -42,4 +42,26 @@ def test_cluster_is_reset_between_workloads():
 
     bmk.start()
 
-    cluster.reset.assert_called_once()
+    assert cluster.create_namespace.call_count == 2
+    assert cluster.delete_namespace.call_count == 2
+
+
+def test_tmp_namespace():
+    cluster = Mock()
+    bmk = Benchmark("foo", cluster)
+
+    with bmk.tmp_namespace() as namespace:
+        assert namespace == "foo"
+        cluster.create_namespace.assert_called_once_with("foo")
+        cluster.delete_namespace.assert_not_called()
+
+    cluster.delete_namespace.assert_called_once_with("foo")
+
+
+def test_workloads_are_applied_in_namespace():
+    cluster = Mock()
+    workload = Mock()
+    bmk = Benchmark("foo", cluster)
+    bmk.run_workload(workload)
+
+    workload.apply.assert_called_once_with(namespace="foo")

--- a/scripts/scale-test/tests/unit/test_cluster.py
+++ b/scripts/scale-test/tests/unit/test_cluster.py
@@ -1,0 +1,39 @@
+import json
+import logging
+from subprocess import CalledProcessError
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from benchmarks.clients import juju
+from benchmarks.cluster import Microk8sCluster
+from benchmarks.models import ClusterInfo, Unit
+
+TEST_UNIT = Unit(name="foo", ip="bar", instance_id="ba")
+
+TEST_CLUSTER_INFO = ClusterInfo(master=TEST_UNIT, control_plane=[TEST_UNIT], workers=[])
+
+
+def test_from_file():
+    read_data = json.dumps(TEST_CLUSTER_INFO.to_dict()).encode()
+
+    with patch("benchmarks.cluster.open", mock_open(read_data=read_data)):
+
+        cluster = Microk8sCluster.from_file("/some/path")
+
+        assert isinstance(cluster, Microk8sCluster)
+        assert cluster.info == TEST_CLUSTER_INFO
+
+
+def test_run_in_unit_logs_process_error(caplog):
+    with patch.object(juju, "run") as _juju_run:
+        error = CalledProcessError(2, "foo")
+        _juju_run.return_value.check_returncode.side_effect = error
+        cluster = Microk8sCluster(info=TEST_CLUSTER_INFO)
+
+        with pytest.raises(CalledProcessError):
+
+            cluster.run_in_unit(cluster.info.master, "blah")
+
+        assert caplog.records[0].levelno == logging.ERROR
+        assert "Error running blah on foo" in caplog.records[0].message

--- a/scripts/scale-test/tests/unit/test_setup_cluster.py
+++ b/scripts/scale-test/tests/unit/test_setup_cluster.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, call, mock_open, patch
 import pytest
 
 from benchmarks.constants import DEFAULT_ADD_NODE_TOKEN, DEFAULT_ADD_NODE_TOKEN_TTL
-from benchmarks.models import Cluster, DockerCredentials, Unit
+from benchmarks.models import ClusterInfo, DockerCredentials, Unit
 from setup_cluster import (
     deploy_units,
     get_docker_credentials,
@@ -69,7 +69,7 @@ def test_get_units(_juju_status):
 def test_save_cluster_info():
     with patch("setup_cluster.open", mock_open()) as _open:
         unit = Unit(name="foo", ip="bar", instance_id="ba")
-        cluster = Cluster(master=unit, control_plane=[unit], workers=[])
+        cluster = ClusterInfo(master=unit, control_plane=[unit], workers=[])
 
         save_cluster_info(cluster)
 

--- a/scripts/scale-test/tests/unit/test_workload.py
+++ b/scripts/scale-test/tests/unit/test_workload.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+
+from benchmarks.workload import Workload
+
+
+@patch("benchmarks.workload.time.time", side_effect=[10, 11, 12, 12])
+@patch("benchmarks.workload.time.sleep")
+def test_wait(_time_sleep, _time_time):
+
+    poll_period = 3
+    wkl = Workload(None, duration=2, poll_period=poll_period)
+    wkl.wait()
+
+    _time_sleep.assert_called_once_with(poll_period)

--- a/scripts/scale-test/workloads/ingress.yaml
+++ b/scripts/scale-test/workloads/ingress.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: microbot
+  name: microbot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: microbot
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: microbot
+    spec:
+      containers:
+        - image: cdkbot/microbot-amd64
+          imagePullPolicy: ""
+          name: microbot
+          ports:
+            - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            timeoutSeconds: 30
+          resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: microbot
+  labels:
+    app: microbot
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: microbot
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: microbot-ingress-nip
+spec:
+  rules:
+    - host: microbot.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: microbot
+                port:
+                  number: 80

--- a/scripts/scale-test/workloads/stateful.yaml
+++ b/scripts/scale-test/workloads/stateful.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+  - port: 80
+    name: web
+  clusterIP: None
+  selector:
+    app: nginx
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: nginx # has to match .spec.template.metadata.labels
+  serviceName: "nginx"
+  replicas: 3 # by default is 1
+  minReadySeconds: 10 # by default is 0
+  template:
+    metadata:
+      labels:
+        app: nginx # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: k8s.gcr.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "my-storage-class"
+      resources:
+        requests:
+          storage: 1Gi

--- a/scripts/scale-test/workloads/stateless.yaml
+++ b/scripts/scale-test/workloads/stateless.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: load-balancer-example
+  name: hello-world
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: load-balancer-example
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: load-balancer-example
+    spec:
+      containers:
+      - image: gcr.io/google-samples/node-hello:1.0
+        name: hello-world
+        ports:
+        - containerPort: 8080


### PR DESCRIPTION
This PR adds the `Benchmark` class that allows registering workloads to run and will deploy them on a specified cluster.

It allows us to declare what kind of workloads we want to run for the scale testing. This is done in the `scale_test.py` script.

Out of scope: all the logic regarding metric collection will come in a later PR.