### PR TITLE
Improve joining nodes in cluster

### DIFF
--- a/scripts/scale-test/benchmarks/clients/juju.py
+++ b/scripts/scale-test/benchmarks/clients/juju.py
@@ -44,7 +44,7 @@ def run(
     else:
         if unit:
             units = [unit]
-        juju_command.extend(["-u", *units, "--", *command])
+        juju_command.extend(["-u", ",".join(units), "--", *command])
     return _juju(*juju_command)
 
 

--- a/scripts/scale-test/benchmarks/clients/juju.py
+++ b/scripts/scale-test/benchmarks/clients/juju.py
@@ -33,7 +33,7 @@ def run(
     Run a command on a juju unit or on all units of a particular application
     """
     args = [unit, units, app]
-    if len([arg for arg in args if arg != None]) != 1:
+    if len([arg for arg in args if arg]) != 1:
         raise ValueError("Need to specify either units, unit or an app")
 
     if unit:

--- a/scripts/scale-test/benchmarks/clients/juju.py
+++ b/scripts/scale-test/benchmarks/clients/juju.py
@@ -24,6 +24,7 @@ def _juju_wait(*args):
 
 def run(
     *command,
+    unit: Optional[Unit] = None,
     units: Optional[List[Unit]] = None,
     app: Optional[str] = None,
     timeout: str = None,
@@ -31,15 +32,18 @@ def run(
     """
     Run a command on a juju unit or on all units of a particular application
     """
-    args = [units, app]
-    if all(args) or not any(args):
-        raise ValueError("Need to specify either units or an app")
+    args = [unit, units, app]
+    if len([arg for arg in args if arg != None]) != 1:
+        raise ValueError("Need to specify either units, unit or an app")
+
     juju_command = ["run"]
     if timeout:
         juju_command.extend(["--timeout", timeout])
     if app:
         juju_command.extend(["-a", app, "--", *command])
     else:
+        if unit:
+            units = [unit]
         juju_command.extend(["-u", *units, "--", *command])
     return _juju(*juju_command)
 

--- a/scripts/scale-test/benchmarks/clients/juju.py
+++ b/scripts/scale-test/benchmarks/clients/juju.py
@@ -36,14 +36,15 @@ def run(
     if len([arg for arg in args if arg != None]) != 1:
         raise ValueError("Need to specify either units, unit or an app")
 
+    if unit:
+        units = [unit]
+
     juju_command = ["run"]
     if timeout:
         juju_command.extend(["--timeout", timeout])
     if app:
         juju_command.extend(["-a", app, "--", *command])
     else:
-        if unit:
-            units = [unit]
         juju_command.extend(["-u", ",".join(units), "--", *command])
     return _juju(*juju_command)
 

--- a/scripts/scale-test/benchmarks/clients/juju.py
+++ b/scripts/scale-test/benchmarks/clients/juju.py
@@ -1,6 +1,6 @@
 import logging
 import subprocess
-from typing import Optional
+from typing import List, Optional
 
 from benchmarks.models import Unit
 
@@ -24,24 +24,23 @@ def _juju_wait(*args):
 
 def run(
     *command,
-    unit: Optional[Unit] = None,
+    units: Optional[List[Unit]] = None,
     app: Optional[str] = None,
     timeout: str = None,
 ):
     """
     Run a command on a juju unit or on all units of a particular application
     """
-    args = [unit, app]
+    args = [units, app]
     if all(args) or not any(args):
-        raise ValueError("Need to specify either a unit or an app")
+        raise ValueError("Need to specify either units or an app")
     juju_command = ["run"]
     if timeout:
         juju_command.extend(["--timeout", timeout])
     if app:
         juju_command.extend(["-a", app, "--", *command])
     else:
-        juju_command.extend(["-u", unit, "--", *command])
-
+        juju_command.extend(["-u", *units, "--", *command])
     return _juju(*juju_command)
 
 

--- a/scripts/scale-test/setup_cluster.py
+++ b/scripts/scale-test/setup_cluster.py
@@ -151,22 +151,15 @@ def setup_cluster(control_plane: int, units: List[Unit]) -> Cluster:
         # Single-node cluster. No nodes to join
         return cluster
 
+    cp_units = units[:control_plane]
+    w_units = units[control_plane:]
     join_url = get_join_cluster_url(master_node)
-    for node in units:
-        if control_plane > 0:
-            cluster.control_plane.append(node)
-            control_plane -= 1
-        else:
-            cluster.workers.append(node)
-
-    # Join them all at once
-    cp_to_join = [node for node in cluster.control_plane if node != master_node]
-    if cp_to_join:
-        join_nodes_to_cluster(cp_to_join, join_url)
-
-    if cluster.workers:
-        join_nodes_to_cluster(cluster.workers, join_url, as_worker=True)
-
+    if cp_units:
+        join_nodes_to_cluster(cp_units, join_url)
+        cluster.control_plane.extend(cp_units)
+    if w_units:
+        join_nodes_to_cluster(w_units, join_url, as_worker=True)
+        cluster.workers.extend(w_units)
     return cluster
 
 

--- a/scripts/scale-test/setup_cluster.py
+++ b/scripts/scale-test/setup_cluster.py
@@ -122,7 +122,7 @@ def get_join_cluster_url(master: Unit) -> str:
     After that, any other node can join the cluster with the returned join url.
     """
     cmd = f"microk8s add-node --token {DEFAULT_ADD_NODE_TOKEN} --token-ttl {DEFAULT_ADD_NODE_TOKEN_TTL}"
-    juju.run(cmd, units=[master.name]).check_returncode()
+    juju.run(cmd, unit=master.name).check_returncode()
     return f"{master.ip}:25000/{DEFAULT_ADD_NODE_TOKEN}"
 
 

--- a/scripts/scale-test/tests/unit/test_juju.py
+++ b/scripts/scale-test/tests/unit/test_juju.py
@@ -16,10 +16,16 @@ def test_run(_juju):
         run(command)
 
     with pytest.raises(ValueError):
+        run(command, unit="foo", app="bar")
+
+    with pytest.raises(ValueError):
         run(command, units=["foo"], app="bar")
 
+    with pytest.raises(ValueError):
+        run(command, units=["foo"], unit="bar")
+
     # a specific unit
-    run(command, units=["foo"])
+    run(command, unit="foo")
     _juju.assert_called_once_with("run", "-u", "foo", "--", command)
     _juju.reset_mock()
 

--- a/scripts/scale-test/tests/unit/test_juju.py
+++ b/scripts/scale-test/tests/unit/test_juju.py
@@ -16,11 +16,16 @@ def test_run(_juju):
         run(command)
 
     with pytest.raises(ValueError):
-        run(command, unit="foo", app="bar")
+        run(command, units=["foo"], app="bar")
 
     # a specific unit
-    run(command, unit="foo")
+    run(command, units=["foo"])
     _juju.assert_called_once_with("run", "-u", "foo", "--", command)
+    _juju.reset_mock()
+
+    # a few units
+    run(command, units=["foo", "bar"])
+    _juju.assert_called_once_with("run", "-u", "foo", "bar", "--", command)
     _juju.reset_mock()
 
     # all units

--- a/scripts/scale-test/tests/unit/test_juju.py
+++ b/scripts/scale-test/tests/unit/test_juju.py
@@ -29,12 +29,12 @@ def test_run(_juju):
     _juju.assert_called_once_with("run", "-u", "foo", "--", command)
     _juju.reset_mock()
 
-    # a few units
+    # two units
     run(command, units=["foo", "bar"])
-    _juju.assert_called_once_with("run", "-u", "foo", "bar", "--", command)
+    _juju.assert_called_once_with("run", "-u", "foo,bar", "--", command)
     _juju.reset_mock()
 
-    # all units
+    # all units in an application
     run(command, app="myapp")
     _juju.assert_called_once_with("run", "-a", "myapp", "--", command)
     _juju.reset_mock()

--- a/scripts/scale-test/tests/unit/test_setup_cluster.py
+++ b/scripts/scale-test/tests/unit/test_setup_cluster.py
@@ -142,7 +142,7 @@ def test_get_join_cluster_url(_juju_run):
     assert join_url == f"{master.ip}:25000/{DEFAULT_ADD_NODE_TOKEN}"
     _juju_run.assert_called_once_with(
         f"microk8s add-node --token {DEFAULT_ADD_NODE_TOKEN} --token-ttl {DEFAULT_ADD_NODE_TOKEN_TTL}",
-        units=[master.name],
+        unit=master.name,
     )
 
 

--- a/scripts/scale-test/tests/unit/test_setup_cluster.py
+++ b/scripts/scale-test/tests/unit/test_setup_cluster.py
@@ -13,7 +13,7 @@ from setup_cluster import (
     get_join_cluster_url,
     get_units,
     install_microk8s,
-    join_node_to_cluster,
+    join_nodes_to_cluster,
     main,
     parse_arguments,
     save_cluster_info,
@@ -78,9 +78,9 @@ def test_save_cluster_info():
 
 
 @patch("setup_cluster.get_join_cluster_url")
-@patch("setup_cluster.join_node_to_cluster")
+@patch("setup_cluster.join_nodes_to_cluster")
 def test_setup_cluster_joins_correct_number_of_worker_nodes(
-    _join_node_to_cluster, _get_join_cluster_url
+    _join_nodes_to_cluster, _get_join_cluster_url
 ):
     master_node = Unit(name="master", ip="masterip", instance_id="masterid")
     other_node = Unit(name="node1", ip="node1ip", instance_id="node1id")
@@ -92,7 +92,9 @@ def test_setup_cluster_joins_correct_number_of_worker_nodes(
 
     _get_join_cluster_url.assert_called_once_with(master_node)
     join_url = _get_join_cluster_url.return_value
-    _join_node_to_cluster.assert_called_once_with(other_node, join_url, as_worker=True)
+    _join_nodes_to_cluster.assert_called_once_with(
+        [other_node], join_url, as_worker=True
+    )
     assert cluster.master == master_node
     assert cluster.control_plane == [master_node]
     assert cluster.workers == [other_node]
@@ -101,8 +103,8 @@ def test_setup_cluster_joins_correct_number_of_worker_nodes(
     units = [master_node, other_node, third_node]
     cluster = setup_cluster(2, units)
 
-    _join_node_to_cluster.assert_has_calls(
-        [call(other_node, join_url), call(third_node, join_url, as_worker=True)]
+    _join_nodes_to_cluster.assert_has_calls(
+        [call([other_node], join_url), call([third_node], join_url, as_worker=True)]
     )
     assert cluster.master == master_node
     assert cluster.control_plane == [master_node, other_node]
@@ -110,24 +112,24 @@ def test_setup_cluster_joins_correct_number_of_worker_nodes(
 
 
 @patch("setup_cluster.juju")
-def test_join_node_to_cluster(_juju):
+def test_join_nodes_to_cluster(_juju):
     node = Mock()
     join_url = "joinme"
 
-    join_node_to_cluster(node, join_url)
+    join_nodes_to_cluster([node], join_url)
 
-    _juju.run.assert_called_once_with(f"microk8s join {join_url}", unit=node.name)
+    _juju.run.assert_called_once_with(f"microk8s join {join_url}", units=[node.name])
 
 
 @patch("setup_cluster.juju")
-def test_join_node_to_cluster_as_worker(_juju):
+def test_join_nodes_to_cluster_as_worker(_juju):
     node = Mock()
     join_url = "joinme"
 
-    join_node_to_cluster(node, join_url, as_worker=True)
+    join_nodes_to_cluster([node], join_url, as_worker=True)
 
     _juju.run.assert_called_once_with(
-        f"microk8s join {join_url} --worker", unit=node.name
+        f"microk8s join {join_url} --worker", units=[node.name]
     )
 
 
@@ -140,7 +142,7 @@ def test_get_join_cluster_url(_juju_run):
     assert join_url == f"{master.ip}:25000/{DEFAULT_ADD_NODE_TOKEN}"
     _juju_run.assert_called_once_with(
         f"microk8s add-node --token {DEFAULT_ADD_NODE_TOKEN} --token-ttl {DEFAULT_ADD_NODE_TOKEN_TTL}",
-        unit=master.name,
+        units=[master.name],
     )
 
 


### PR DESCRIPTION
This PR makes the process of joining nodes to the cluster much faster.

Before we were iterating all nodes and issuing a `juju run` command for each of them. Now we run just two `juju run` commands: one for control plane nodes and one for worker nodes.