### PR TITLE
Add back logic to set http proxy on /etc/environment

### DIFF
--- a/scripts/scale-test/README.md
+++ b/scripts/scale-test/README.md
@@ -27,9 +27,9 @@ Once a juju controller has been setup, you can use the `setup_cluster.py` script
 python scripts/scale-test/setup_cluster.py -m "mycluster" --nodes 10 --control-plane 3
 ```
 
-will create a new juju model named `mycluster`, spin up 10 ubuntu instances on it and install `microk8s`. After that, it will join nodes as workers or not depending on the number of control-plane nodes were specified.
+will create a new juju model named `mycluster`, spin up 10 ubuntu instances on it and install `microk8s`. After that, it will join nodes as workers or not depending on the number of control-plane nodes were specified. You can also specify which channel you want to install by using the `--channel` argument.
 
-Check out `python setup_cluster.py -h` for more detailed instructions on how to use the tool.
+Check out `python setup_cluster.py --help` for more detailed instructions on how to use the tool.
 
 #### Docker credentials
 If you are trying to setup a large cluster, you will most probably hit dockerhub rate-limit errors (see [this documentation page](https://microk8s.io/docs/dockerhub-limits)).

--- a/scripts/scale-test/scale_test.py
+++ b/scripts/scale-test/scale_test.py
@@ -40,7 +40,7 @@ def main():
     scaletest = Benchmark(
         "scale_testing",
         cluster=cluster,
-        required_addons=["dns", "hostpath-storage"],  # , "prometheus"],
+        required_addons=["dns", "hostpath-storage", "prometheus"],
     )
     scaletest.register_workloads(
         [

--- a/scripts/scale-test/setup_cluster.py
+++ b/scripts/scale-test/setup_cluster.py
@@ -51,8 +51,9 @@ def configure_http_proxy(http_proxy: str):
             f"echo HTTP_PROXY={http_proxy} >> /etc/environment",
             f"echo https_proxy={http_proxy} >> /etc/environment",
             f"echo http_proxy={http_proxy} >> /etc/environment",
+            "local_ip=$(hostname -I) | awk '{print $1}'",
             "juju_instance_id=$(grep \"juju\" /etc/hosts | head -n 1 | awk '{print $NF}')",
-            'noproxy="10.0.0.0/8,127.0.0.0/8,192.168.0.0/16,${juju_instance_id}"',
+            'noproxy="10.1.0.0/16,10.152.183.0/24,127.0.0.1,${local_ip},${juju_instance_id}"',
             "echo no_proxy=${noproxy} >> /etc/environment",
             "echo NO_PROXY=${noproxy} >> /etc/environment",
         ]
@@ -112,9 +113,9 @@ def install_snap(channel: str):
     logging.info("Installing microk8s on all units")
     all_commands = [
         f"snap install microk8s --classic --channel={channel}",
-        "sudo usermod -a -G microk8s ubuntu",
-        "sudo chown -f -R ubuntu ~/.kube",
-        "sudo newgrp microk8s",
+        "usermod -a -G microk8s ubuntu",
+        "chown -f -R ubuntu ~/.kube",
+        "newgrp microk8s",
     ]
     command = ";".join(all_commands)
     juju.run(command, app=APP_NAME).check_returncode()

--- a/scripts/scale-test/tests/unit/test_setup_cluster.py
+++ b/scripts/scale-test/tests/unit/test_setup_cluster.py
@@ -147,27 +147,43 @@ def test_get_join_cluster_url(_juju_run):
 @patch("setup_cluster.wait_microk8s_ready")
 @patch("setup_cluster.update_etc_hosts")
 @patch("setup_cluster.install_snap")
-@patch("setup_cluster.restart_containerd")
 @patch("setup_cluster.configure_containerd")
-def test_install_microk8s_configures_containerd_only_if_proxy_or_creds_provided(
+def test_install_microk8s_configures_containerd_iif_provided(
     _configure_containerd,
-    _restart_containerd,
     _install_snap,
     update_etc_hosts,
     _wait_microk8s_ready,
 ):
     units = []
-    http_proxy = "http://myproxy"
     creds = DockerCredentials(username="foo", password="bar")
-    install_microk8s(Mock(), units)
+    install_microk8s("model", units)
+
     _configure_containerd.assert_not_called()
 
-    install_microk8s(Mock(), units, http_proxy=http_proxy)
-    _configure_containerd.assert_called_once_with(None, http_proxy)
-    _configure_containerd.reset_mock()
+    install_microk8s("model", units, creds=creds)
+    _configure_containerd.assert_called_once_with(creds)
 
-    install_microk8s(Mock(), units, creds=creds)
-    _configure_containerd.assert_called_once_with(creds, None)
+
+@patch("setup_cluster.wait_microk8s_ready")
+@patch("setup_cluster.update_etc_hosts")
+@patch("setup_cluster.install_snap")
+@patch("setup_cluster.configure_http_proxy")
+@patch("setup_cluster.reboot_and_wait")
+def test_install_microk8s_configures_http_proxy_iif_provided(
+    _reboot_and_wait,
+    _configure_http_proxy,
+    _install_snap,
+    _update_etc_hosts,
+    _wait_microk8s_ready,
+):
+    install_microk8s("model", [])
+    _configure_http_proxy.assert_not_called()
+    _reboot_and_wait.assert_not_called()
+
+    http_proxy = "http://proxy:3128"
+    install_microk8s("model", [], http_proxy=http_proxy)
+    _configure_http_proxy.assert_called_once_with(http_proxy)
+    _reboot_and_wait.assert_called_once_with("model")
 
 
 def test_get_docker_credentials():


### PR DESCRIPTION
This PR adds back the logic that configures HTTP_PROXY on `/etc/environment` for all nodes. 
This is needed because some addons (like prometheus) need internet access to download some binaries.