### PR TITLE
Naming change: benchmark.Benchmark -> experiment.Experiment

### DIFF
--- a/scripts/scale-test/benchmarks/experiment.py
+++ b/scripts/scale-test/benchmarks/experiment.py
@@ -6,7 +6,7 @@ from benchmarks.cluster import Microk8sCluster
 from benchmarks.workload import Workload
 
 
-class Benchmark:
+class Experiment:
     """
     Manages runtime of a benchmark experiment on top of a Microk8s cluster.
     """

--- a/scripts/scale-test/scale_test.py
+++ b/scripts/scale-test/scale_test.py
@@ -4,8 +4,8 @@ import argparse
 import logging
 from pathlib import Path
 
-from benchmarks.benchmark import Benchmark
 from benchmarks.cluster import Microk8sCluster
+from benchmarks.experiment import Experiment
 from benchmarks.workload import Workload
 
 MINUTE = 60
@@ -37,7 +37,7 @@ def main():
     args = parse_args()
     configure_logging(args)
     cluster = Microk8sCluster.from_file(Path(args.cluster_file))
-    scaletest = Benchmark(
+    scaletest = Experiment(
         "scale_testing",
         cluster=cluster,
         required_addons=["dns", "hostpath-storage", "prometheus"],


### PR DESCRIPTION
This PR is simply a naming change to better reflect what a benchmark is: a benchmark is a collection of experiments. Each experiment is a set of workloads deployed in a particular cluster.