### PR TITLE
Added coverage reports for unit and integration tests

### DIFF
--- a/scripts/scale-test/tox.ini
+++ b/scripts/scale-test/tox.ini
@@ -7,37 +7,50 @@ envlist = lint, unit, integration
 basepython = python3
 envdir = {toxinidir}/.tox_env
 
+[vars]
+benchmarklib_path = {toxinidir}/benchmarklib/
+scale_test_path = {toxinidir}/scale_test/
+setup_cluster_path = {toxinidir}/setup_cluster.py
+tests_path = {toxinidir}/tests/
+all_path = {[vars]benchmarklib_path} {[vars]scale_test_path} {[vars]setup_cluster_path} {[vars]tests_path}
+
 [testenv:lint]
 deps =
     black
     flake8
 commands =
-    flake8 --max-line-length=120 --ignore=C901,N801,N802,N803,N806,N816
-    black --diff --check --exclude "/(\.eggs|\.git|.tox_env|\.tox|venv|\.build|dist|charmhelpers|mod)/" .
+    flake8 --max-line-length=120 --ignore=C901,N801,N802,N803,N806,N816 {[vars]all_path}
+    black --diff --check {[vars]all_path}
 
 [testenv:fmt]
 deps =
     black
     isort
 commands =
-    isort . --skip .tox_env --skip venv
-    black --exclude "/(\.eggs|\.git|.tox_env|\.tox|venv|\.build|dist|charmhelpers|mod)/" .
+    isort {[vars]all_path}
+    black {[vars]all_path}
 
 [testenv:unit]
 setenv = PYTHONPATH={toxinidir}
 deps = 
     pytest
     pdbpp
+    coverage[toml]
 commands =
-    pytest -s tests/unit {posargs}
+    coverage run --data-file=.coverage.unit --source={[vars]benchmarklib_path},{[vars]setup_cluster_path},{[vars]scale_test_path} -m pytest -s tests/unit -v --tb native -s {posargs}
+    coverage report --data-file=.coverage.unit
+    coverage html --data-file=.coverage.unit --directory=htmlcov/unit
 
 [testenv:integration]
 setenv = PYTHONPATH={toxinidir}
 deps = 
     pytest
     pdbpp
+    coverage[toml]
 commands =
-    pytest -s tests/integration {posargs}
+    coverage run --data-file=.coverage.integration --source={[vars]benchmarklib_path},{[vars]setup_cluster_path},{[vars]scale_test_path} -m pytest -s tests/integration -v --tb native -s {posargs}
+    coverage report --data-file=.coverage.integration
+    coverage html --data-file=.coverage.integration --directory=htmlcov/integration
 
 [flake8]
 exclude =


### PR DESCRIPTION
This PR modifies tox.ini so that a coverage report is created for unit and for integration tests.

I decided not to integrate it with github-actions and codecov yet.