### PR TITLE
Refactor setup_cluster.py to use JujuSession

### DIFF
--- a/scripts/scale-test/benchmarklib/experiment.py
+++ b/scripts/scale-test/benchmarklib/experiment.py
@@ -78,7 +78,6 @@ class Experiment:
             with WorkloadMetrics(
                 workload=workload,
                 metrics=self.get_metrics_for_workload(workload),
-                poll_period=10,
                 store_at=self.store_metrics_at,
             ):
                 workload.wait()
@@ -124,11 +123,10 @@ class WorkloadMetrics(MetricsCollector):
         workload: Workload,
         metrics: List[Metric],
         store_at: Path,
-        poll_period: int = 10,
     ):
         self.workload = workload
         self.workload_field = ConstantField("workload", self.workload_id)
-        super().__init__(metrics=metrics, store_at=store_at, poll_period=poll_period)
+        super().__init__(metrics=metrics, store_at=store_at)
 
     @property
     def workload_id(self):

--- a/scripts/scale-test/benchmarklib/metrics/collector.py
+++ b/scripts/scale-test/benchmarklib/metrics/collector.py
@@ -2,10 +2,12 @@ import logging
 import threading
 import time
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from benchmarklib.metrics.base import Metric
 from benchmarklib.utils import pp_time
+
+DEFAULT_POLL_PERIOD = 10
 
 
 class MetricsCollector:
@@ -17,11 +19,11 @@ class MetricsCollector:
         self,
         metrics: List[Metric],
         store_at: Path,
-        poll_period: int = 10,
+        poll_period: Optional[int] = None,
     ):
         self.metrics = metrics
         self.store_at = store_at
-        self.poll_period = poll_period
+        self.poll_period = poll_period or DEFAULT_POLL_PERIOD
         self._started: bool = False
         self.thread = None
 

--- a/scripts/scale-test/benchmarklib/models.py
+++ b/scripts/scale-test/benchmarklib/models.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from typing import Dict, List
 
@@ -45,3 +46,10 @@ class ClusterInfo:
 class DockerCredentials:
     username: str
     password: str
+
+    @classmethod
+    def from_env(klass):
+        return klass(
+            username=os.environ["DOCKER_USERNAME"],
+            password=os.environ["DOCKER_PASSWORD"],
+        )

--- a/scripts/scale-test/setup_cluster.py
+++ b/scripts/scale-test/setup_cluster.py
@@ -2,303 +2,305 @@
 
 import json
 import logging
-import os
 import time
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from typing import List, Optional
 
-from benchmarklib.clients import juju
+from benchmarklib.clients.juju import JujuSession
 from benchmarklib.constants import DEFAULT_ADD_NODE_TOKEN, DEFAULT_ADD_NODE_TOKEN_TTL
 from benchmarklib.models import ClusterInfo, DockerCredentials, Unit
 from benchmarklib.utils import timeit
 
 APP_NAME = "microk8s-node"
 DEFAULT_CHANNEL = "1.24/stable"
-MINUTE = 60
-
 LOG_FORMAT = "[%(asctime)s] [%(levelname)8s] --- %(message)s"
 LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
 logging.basicConfig(format=LOG_FORMAT, level=logging.INFO, datefmt=LOG_DATEFMT)
 
 
-@timeit
-def install_microk8s(
-    model: str,
-    units: List[Unit],
-    channel: str = DEFAULT_CHANNEL,
-    http_proxy: Optional[str] = None,
-    creds: Optional[DockerCredentials] = None,
-):
-    if http_proxy:
-        configure_http_proxy(http_proxy)
-        reboot_and_wait(model)
+class JujuClusterSetup:
+    """
+    Setup a microk8s cluster via the juju client
+    """
 
-    install_snap(channel)
-    update_etc_hosts(units)
+    def __init__(
+        self,
+        model: str,
+        total_nodes: int,
+        control_plane_nodes: int,
+        channel: str,
+        http_proxy: Optional[str] = None,
+        creds: Optional[DockerCredentials] = None,
+    ):
+        self.juju = JujuSession(model=model, app=APP_NAME)
+        self.total_nodes = total_nodes
+        self.control_plane_nodes = control_plane_nodes
+        self.channel = channel
+        self.http_proxy = http_proxy
+        self.creds = creds
+        self.units: List[Unit] = []
 
-    if creds:
-        configure_containerd(creds)
+    def install_microk8s(
+        self,
+        channel: str,
+        http_proxy: Optional[str] = None,
+        creds: Optional[DockerCredentials] = None,
+    ):
+        """
+        Installs microk8s snaps on all deployed units.
+        It will configure http proxy and containerd settings if specified.
+        """
+        if http_proxy:
+            self.configure_http_proxy(http_proxy)
+            self.reboot_and_wait()
 
-    wait_microk8s_ready()
+        self.install_snap(channel)
+        self.update_etc_hosts()
 
+        if creds:
+            self.configure_containerd(creds)
 
-@timeit
-def configure_http_proxy(http_proxy: str):
-    logging.info("Configuring proxy settings on units")
-    commands = ";".join(
-        [
-            f"echo HTTPS_PROXY={http_proxy} >> /etc/environment",
-            f"echo HTTP_PROXY={http_proxy} >> /etc/environment",
-            f"echo https_proxy={http_proxy} >> /etc/environment",
-            f"echo http_proxy={http_proxy} >> /etc/environment",
-            "local_ip=$(hostname -I | awk '{print $1}')",
-            "juju_instance_id=$(grep \"juju\" /etc/hosts | head -n 1 | awk '{print $NF}')",
-            'noproxy="10.0.0.0/8,127.0.0.1,${local_ip},${juju_instance_id}"',
-            "echo no_proxy=${noproxy} >> /etc/environment",
-            "echo NO_PROXY=${noproxy} >> /etc/environment",
+        self.wait_microk8s_ready()
+
+    def configure_http_proxy(self, http_proxy: str):
+        logging.info("Configuring proxy settings on units")
+        commands = ";".join(
+            [
+                f"echo HTTPS_PROXY={http_proxy} >> /etc/environment",
+                f"echo HTTP_PROXY={http_proxy} >> /etc/environment",
+                f"echo https_proxy={http_proxy} >> /etc/environment",
+                f"echo http_proxy={http_proxy} >> /etc/environment",
+                "local_ip=$(hostname -I | awk '{print $1}')",
+                "juju_instance_id=$(grep \"juju\" /etc/hosts | head -n 1 | awk '{print $NF}')",
+                'noproxy="10.0.0.0/8,127.0.0.1,${local_ip},${juju_instance_id}"',
+                "echo no_proxy=${noproxy} >> /etc/environment",
+                "echo NO_PROXY=${noproxy} >> /etc/environment",
+            ]
+        )
+        self.juju.run_in_all_units(commands).check_returncode()
+
+    def reboot_and_wait(self):
+        """
+        Reboots all units in the model and then waits for them to be up.
+        """
+        logging.info("Rebooting all units")
+        self.juju.run_in_all_units("reboot", timeout="10s")
+
+        logging.info(f"Waiting for {self.juju.model} model...")
+        self.juju.wait_for_model()
+
+    def restart_containerd(self):
+        cmd = "sudo snap restart microk8s.daemon-containerd"
+        self.juju.run_in_all_units(cmd).check_returncode()
+
+    def configure_containerd(self, creds: DockerCredentials):
+        """
+        Configure docker credentials if specified.
+        """
+        self.configure_containerd_credentials(creds)
+        self.restart_containerd()
+
+    def configure_containerd_credentials(self, creds: DockerCredentials):
+        logging.info("Configuring containerd docker credentials")
+        containerd_file = "/var/snap/microk8s/current/args/containerd-template.toml"
+        lines = [
+            '[plugins.\\"io.containerd.grpc.v1.cri\\".registry.configs.\\"registry-1.docker.io\\".auth]',
+            f'username = \\"{creds.username}\\"',
+            f'password = \\"{creds.password}\\"',
         ]
-    )
-    juju.run(commands, app=APP_NAME).check_returncode()
+        cmd = ";".join([f'echo "{line}" >> {containerd_file}' for line in lines])
+        self.juju.run_in_all_units(cmd).check_returncode()
 
+    def update_etc_hosts(self):
+        """
+        Add entries in /etc/hosts of all units for each node in the cluster.
+        This is needed as nodes's hostnames need to be resolvable in order for
+        the add-node/join process to work.
+        """
+        logging.info("Adding units hostnames on /etc/hosts")
+        command = ";".join(
+            [f"echo {u.ip}\t{u.instance_id} >> /etc/hosts" for u in self.units]
+        )
+        self.juju.run_in_all_units(command).check_returncode()
 
-def reboot_and_wait(model: str):
-    """
-    Reboots all units in the model and then waits for them to be up.
-    """
-    logging.info("Rebooting all units")
-    juju.run("reboot", app=APP_NAME, timeout="10s")
+    def install_snap(self, channel: str):
+        logging.info("Installing microk8s on all units")
+        all_commands = [
+            f"snap install microk8s --classic --channel={channel}",
+            "usermod -a -G microk8s ubuntu",
+            "chown -f -R ubuntu ~/.kube",
+            "newgrp microk8s",
+        ]
+        command = ";".join(all_commands)
+        self.juju.run_in_all_units(command).check_returncode()
 
-    logging.info(f"Waiting for {model} model...")
-    juju.wait_for_model(model)
+    def wait_microk8s_ready(self, timeout_min: int = 10):
+        cmd = f"microk8s status --wait-ready --timeout {timeout_min * 60}"
+        self.juju.run_in_all_units(cmd).check_returncode()
 
+    def get_join_cluster_url(self, master: Unit) -> str:
+        """
+        Executes the microk8s add-node command at the master node with a non-expiring fixed token.
+        After that, any other node can join the cluster with the returned join url.
+        """
+        cmd = f"microk8s add-node --token {DEFAULT_ADD_NODE_TOKEN} --token-ttl {DEFAULT_ADD_NODE_TOKEN_TTL}"
+        self.juju.run_in_unit(cmd, unit=master.name).check_returncode()
+        return f"{master.ip}:25000/{DEFAULT_ADD_NODE_TOKEN}"
 
-def restart_containerd():
-    cmd = "sudo snap restart microk8s.daemon-containerd"
-    juju.run(cmd, app=APP_NAME).check_returncode()
+    def join_nodes_to_cluster(
+        self, nodes: List[Unit], join_url: str, as_worker: bool = False
+    ):
+        nodes = [node.name for node in nodes]
+        join_command = f"microk8s join {join_url}"
+        if as_worker:
+            join_command += " --worker"
+            logging.info(f"Joining worker nodes to cluster: {nodes}")
+        else:
+            logging.info(f"Joining control plane nodes to cluster: {nodes}")
+        resp = self.juju.run_in_units(join_command, units=nodes)
+        resp.check_returncode()
+        logging.debug(f"Join output: {resp.stdout.decode()[:1000]}")
 
+    def wait_for_nodes_to_join(self, cluster: ClusterInfo, max_wait: int = 5 * 60):
+        logging.info("Waiting for nodes to join the cluster...")
+        check_period = 30
 
-def configure_containerd(creds: DockerCredentials):
-    """
-    Configure docker credentials if specified.
-    """
-    configure_containerd_credentials(creds)
-    restart_containerd()
-
-
-def configure_containerd_credentials(creds: DockerCredentials):
-    logging.info("Configuring containerd docker credentials")
-    containerd_file = "/var/snap/microk8s/current/args/containerd-template.toml"
-    lines = [
-        '[plugins.\\"io.containerd.grpc.v1.cri\\".registry.configs.\\"registry-1.docker.io\\".auth]',
-        f'username = \\"{creds.username}\\"',
-        f'password = \\"{creds.password}\\"',
-    ]
-    cmd = ";".join([f'echo "{line}" >> {containerd_file}' for line in lines])
-    juju.run(cmd, app=APP_NAME).check_returncode()
-
-
-def update_etc_hosts(units: List[Unit]):
-    """
-    Add entries in /etc/hosts of all units for each node in the cluster.
-    This is needed as nodes's hostnames need to be resolvable in order for
-    the add-node/join process to work.
-    """
-    logging.info("Adding units hostnames on /etc/hosts")
-    command = ";".join([f"echo {u.ip}\t{u.instance_id} >> /etc/hosts" for u in units])
-    juju.run(command, app=APP_NAME).check_returncode()
-
-
-@timeit
-def install_snap(channel: str):
-    logging.info("Installing microk8s on all units")
-    all_commands = [
-        f"snap install microk8s --classic --channel={channel}",
-        "usermod -a -G microk8s ubuntu",
-        "chown -f -R ubuntu ~/.kube",
-        "newgrp microk8s",
-    ]
-    command = ";".join(all_commands)
-    juju.run(command, app=APP_NAME).check_returncode()
-
-
-@timeit
-def wait_microk8s_ready(timeout_min: int = 10):
-    cmd = f"microk8s status --wait-ready --timeout {timeout_min * 60}"
-    juju.run(cmd, app=APP_NAME).check_returncode()
-
-
-def get_join_cluster_url(master: Unit) -> str:
-    """
-    Executes the microk8s add-node command at the master node with a non-expiring fixed token.
-    After that, any other node can join the cluster with the returned join url.
-    """
-    cmd = f"microk8s add-node --token {DEFAULT_ADD_NODE_TOKEN} --token-ttl {DEFAULT_ADD_NODE_TOKEN_TTL}"
-    juju.run(cmd, unit=master.name).check_returncode()
-    return f"{master.ip}:25000/{DEFAULT_ADD_NODE_TOKEN}"
-
-
-@timeit
-def join_nodes_to_cluster(nodes: List[Unit], join_url: str, as_worker: bool = False):
-    nodes = [node.name for node in nodes]
-    join_command = f"microk8s join {join_url}"
-    if as_worker:
-        join_command += " --worker"
-        logging.info(f"Joining worker nodes to cluster: {nodes}")
-    else:
-        logging.info(f"Joining control plane nodes to cluster: {nodes}")
-    resp = juju.run(join_command, units=nodes)
-    resp.check_returncode()
-    logging.debug(f"Join output: {resp.stdout.decode()[:1000]}")
-
-
-@timeit
-def wait_for_nodes_to_join(cluster: ClusterInfo, max_wait: int = 5 * MINUTE):
-    logging.info("Waiting for nodes to join the cluster...")
-    check_period = 30
-
-    start = time.time()
-    while True:
-        if all_nodes_joined(cluster):
-            logging.info("All nodes have joined the cluster")
-            break
-
-        if (time.time() - start) > max_wait:
-            logging.warning("Some nodes haven't joined the cluster yet")
-            break
-
-        time.sleep(check_period)
-
-
-def all_nodes_joined(cluster: ClusterInfo) -> bool:
-    """
-    Check whether all nodes in the cluster appear as ready
-    in the kubectl get nodes command.
-    """
-    # Get nodes readiness info
-    command = "microk8s.kubectl get nodes -o json"
-    resp = juju.run(command, unit=cluster.master.name)
-    resp.check_returncode()
-    kubectl_get_nodes = json.loads(resp.stdout.decode())
-
-    # Parse output to check that all cluster nodes show up as ready
-    cluster_ids = [node.instance_id for node in cluster.nodes]
-    for item in kubectl_get_nodes["items"]:
-        if item["kind"] != "Node":
-            continue
-
-        node_id = item["metadata"]["name"]
-        if node_id not in cluster_ids:
-            logging.warning(f"Node not known to cluster {node_id}. Ignoring...")
-            continue
-
-        is_ready = False
-        for condition in item["status"]["conditions"]:
-            if (
-                condition["type"] == "Ready"  # noqa
-                and condition["status"] == "True"  # noqa
-                and condition["reason"] == "KubeletReady"  # noqa
-            ):
-                is_ready = True
+        start = time.time()
+        while True:
+            if self.all_nodes_joined(cluster):
+                logging.info("All nodes have joined the cluster")
                 break
 
-        if is_ready:
-            cluster_ids.remove(node_id)
+            if (time.time() - start) > max_wait:
+                logging.warning("Some nodes haven't joined the cluster yet")
+                break
 
-    if cluster_ids != []:
-        logging.debug(f"Some nodes are not ready yet: {','.join(cluster_ids)}")
-        return False
+            time.sleep(check_period)
 
-    return True
+    def all_nodes_joined(self, cluster: ClusterInfo) -> bool:
+        """
+        Check whether all nodes in the cluster appear as ready
+        in the kubectl get nodes command.
+        """
+        # Get nodes readiness info
+        command = "microk8s.kubectl get nodes -o json"
+        resp = self.juju.run_in_unit(command, unit=cluster.master.name)
+        resp.check_returncode()
+        kubectl_get_nodes = json.loads(resp.stdout.decode())
 
+        # Parse output to check that all cluster nodes show up as ready
+        cluster_ids = [node.instance_id for node in cluster.nodes]
+        for item in kubectl_get_nodes["items"]:
+            if item["kind"] != "Node":
+                continue
 
-@timeit
-def setup_cluster(control_plane: int, units: List[Unit], model: str) -> ClusterInfo:
-    n_workers = len(units) - control_plane
-    logging.info(
-        f"Setting up a microk8s cluster: {n_workers} workers and {control_plane} control-plane nodes"
-    )
-    master_node = units.pop(0)
-    control_plane -= 1  # master is running control plane already
-    cluster = ClusterInfo(
-        model=model, master=master_node, control_plane=[master_node], workers=[]
-    )
-    if len(units) == 0:
-        # Single-node cluster. No nodes to join
+            node_id = item["metadata"]["name"]
+            if node_id not in cluster_ids:
+                logging.warning(f"Node not known to cluster {node_id}. Ignoring...")
+                continue
+
+            is_ready = False
+            for condition in item["status"]["conditions"]:
+                if (
+                    condition["type"] == "Ready"  # noqa
+                    and condition["status"] == "True"  # noqa
+                    and condition["reason"] == "KubeletReady"  # noqa
+                ):
+                    is_ready = True
+                    break
+
+            if is_ready:
+                cluster_ids.remove(node_id)
+
+        if cluster_ids != []:
+            logging.debug(f"Some nodes are not ready yet: {','.join(cluster_ids)}")
+            return False
+
+        return True
+
+    def form_cluster(self, control_plane: int) -> ClusterInfo:
+        units = self.units[:]
+        n_workers = len(units) - control_plane
+        logging.info(
+            f"Setting up a microk8s cluster: {n_workers} workers and {control_plane} control-plane nodes"
+        )
+        master_node = units.pop(0)
+        control_plane -= 1  # master is running control plane already
+        cluster = ClusterInfo(
+            model=self.juju.model,
+            master=master_node,
+            control_plane=[master_node],
+            workers=[],
+        )
+        if len(units) == 0:
+            # Single-node cluster. No nodes to join
+            return cluster
+
+        cp_units = units[:control_plane]
+        w_units = units[control_plane:]
+        join_url = self.get_join_cluster_url(master_node)
+        if cp_units:
+            self.join_nodes_to_cluster(cp_units, join_url)
+            cluster.control_plane.extend(cp_units)
+        if w_units:
+            self.join_nodes_to_cluster(w_units, join_url, as_worker=True)
+            cluster.workers.extend(w_units)
+
+        self.wait_for_nodes_to_join(cluster, max_wait=10 * 60)
         return cluster
 
-    cp_units = units[:control_plane]
-    w_units = units[control_plane:]
-    join_url = get_join_cluster_url(master_node)
-    if cp_units:
-        join_nodes_to_cluster(cp_units, join_url)
-        cluster.control_plane.extend(cp_units)
-    if w_units:
-        join_nodes_to_cluster(w_units, join_url, as_worker=True)
-        cluster.workers.extend(w_units)
+    def deploy_units(self, n_units: int) -> List[Unit]:
+        logging.info(f"Deploying {n_units} ubuntu charm units")
+        self.juju.add_model().check_returncode()
+        self.juju.deploy(
+            "ubuntu",
+            "--series=focal",
+            "--constraints=mem=4G cores=2 root-disk=40G",
+        ).check_returncode()
+        replicas = n_units - 1
+        if replicas > 0:
+            self.juju.add_units(replicas).check_returncode()
+        self.juju.wait_for_model()
+        self.units = self.juju.get_units()
 
-    wait_for_nodes_to_join(cluster, max_wait=10 * MINUTE)
-    return cluster
+    def save_cluster_info(self, cluster: ClusterInfo):
+        clusters_path = Path.cwd() / ".clusters"
+        clusters_path.mkdir(parents=True, exist_ok=True)
 
+        path = clusters_path / f"{cluster.model}.json"
+        logging.info(f"Saving cluster info to {path}")
+        with open(path, "w") as f:
+            f.write(json.dumps(cluster.to_dict()))
 
-def save_cluster_info(cluster: ClusterInfo):
-    clusters_path = Path.cwd() / ".clusters"
-    clusters_path.mkdir(parents=True, exist_ok=True)
-
-    path = clusters_path / f"{cluster.model}.json"
-    logging.info(f"Saving cluster info to {path}")
-    with open(path, "w") as f:
-        f.write(json.dumps(cluster.to_dict()))
-
-
-def get_units() -> List[Unit]:
-    """
-    Build the list of ubuntu units from the juju status output
-    """
-    units = []
-    status = json.loads(juju.status(format="json").stdout.decode())
-    for unit_name, unit_data in status["applications"][APP_NAME]["units"].items():
-        ip = unit_data["public-address"]
-        machine_id = unit_data["machine"]
-        hostname = status["machines"][machine_id]["hostname"]
-        units.append(Unit(name=unit_name, instance_id=hostname, ip=ip))
-    return units
+    def setup(self) -> ClusterInfo:
+        self.deploy_units(self.total_nodes)
+        self.install_microk8s(
+            channel=self.channel,
+            http_proxy=self.http_proxy,
+            creds=self.creds,
+        )
+        cluster_info = self.form_cluster(self.control_plane_nodes)
+        self.save_cluster_info(cluster_info)
+        return cluster_info
 
 
-@timeit
-def deploy_units(model: str, n_units: int) -> List[Unit]:
-    logging.info(f"Deploying {n_units} ubuntu charm units")
-    juju.add_model(model).check_returncode()
-    juju.deploy(
-        "ubuntu",
-        "--series=focal",
-        "--constraints=mem=4G cores=2 root-disk=40G",
-        APP_NAME,
-    ).check_returncode()
-    replicas = n_units - 1
-    if replicas > 0:
-        juju.add_unit(replicas, APP_NAME).check_returncode()
-    juju.wait_for_model(model)
-    return get_units()
-
-
-def get_docker_credentials(args: Namespace) -> Optional[DockerCredentials]:
+def get_docker_credentials(
+    args: Namespace,
+) -> Optional[DockerCredentials]:
     """
     Get docker credentials from arguments or environment variables (in this order).
     """
-    if args.docker_username and args.docker_password:
+    if args and (args.docker_username and args.docker_password):
         return DockerCredentials(
             username=args.docker_username,
             password=args.docker_password,
         )
-    elif os.environ.get("DOCKER_USERNAME") and os.environ.get("DOCKER_PASSWORD"):
-        logging.debug("docker credentials found from env vars")
-        return DockerCredentials(
-            username=os.environ["DOCKER_USERNAME"],
-            password=os.environ["DOCKER_PASSWORD"],
-        )
-    logging.debug("docker credentials not provided")
-    return None
+    try:
+        return DockerCredentials.from_env()
+    except KeyError:
+        logging.debug("docker credentials not provided")
+        return None
 
 
 def parse_arguments() -> Namespace:
@@ -368,24 +370,40 @@ def configure_logging(debug: bool = False):
 
 def destroy_model(model: str):
     logging.warning(f"Destroying model {model}")
-    juju.destroy_model(model)
+    JujuSession(model, APP_NAME).destroy_model()
+
+
+def setup_cluster(
+    model: str,
+    total_nodes: int,
+    control_plane: int,
+    channel: str,
+    http_proxy: Optional[str] = None,
+    creds: Optional[DockerCredentials] = None,
+) -> ClusterInfo:
+    mgr = JujuClusterSetup(
+        model,
+        total_nodes,
+        control_plane,
+        channel,
+        http_proxy=http_proxy,
+        creds=creds,
+    )
+    return mgr.setup()
 
 
 @timeit
 def main():
     args = parse_arguments()
-    model = args.model
     try:
-        units = deploy_units(model, args.nodes)
-        install_microk8s(
-            model,
-            units,
-            channel=args.channel,
+        setup_cluster(
+            args.model,
+            args.nodes,
+            args.control_plane,
+            args.channel,
             http_proxy=args.http_proxy,
             creds=get_docker_credentials(args),
         )
-        cluster = setup_cluster(args.control_plane, units, model)
-        save_cluster_info(cluster)
     except KeyboardInterrupt:
         logging.info("CTRL+C catched! exiting...")
     except Exception:

--- a/scripts/scale-test/tests/integration/conftest.py
+++ b/scripts/scale-test/tests/integration/conftest.py
@@ -1,19 +1,22 @@
 import json
 import subprocess
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from benchmarklib.clients import juju
+from benchmarklib.clients.juju import JujuSession
+from benchmarklib.metrics import collector
 from benchmarklib.models import ClusterInfo, Unit
+from scale_test import experiment
 
 TEST_JUJU_STATUS_OUTPUT = b"""{"model":{"name":"microk8s","type":"iaas","controller":"mk8s-testing-controller","cloud":"mk8s-testing","region":"Boston","version":"2.9.29","model-status":{"current":"available","since":"26 May 2022 12:58:26+02:00"},"sla":"unsupported"},"machines":{"0":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-0","dns-name":"10.246.154.108","ip-addresses":["10.246.154.108"],"instance-id":"juju-c6c89a-0","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.108"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"},"1":{"juju-status":{"current":"started","since":"26 May 2022 13:02:29+02:00","version":"2.9.29"},"hostname":"juju-c6c89a-1","dns-name":"10.246.154.111","ip-addresses":["10.246.154.111"],"instance-id":"juju-c6c89a-1","machine-status":{"current":"allocating","message":"powering on","since":"26 May 2022 12:58:46+02:00"},"modification-status":{"current":"idle","since":"26 May 2022 12:58:35+02:00"},"series":"focal","network-interfaces":{"ens192":{"ip-addresses":["10.246.154.111"],"mac-address":"00:50:56:09:5c:07","gateway":"10.246.154.1","is-up":true}},"constraints":"arch=amd64 cores=2 mem=4096M root-disk=40960M","hardware":"arch=amd64 cores=2 mem=4096M root-disk=40960M root-disk-source=vsanDatastore"}},"applications":{"microk8s-node":{"charm":"ubuntu","series":"focal","os":"ubuntu","charm-origin":"charmhub","charm-name":"ubuntu","charm-rev":19,"charm-channel":"stable","exposed":false,"application-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"units":{"microk8s-node/0":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":true,"machine":"0","public-address":"10.246.154.108"},"microk8s-node/1":{"workload-status":{"current":"active","since":"26 May 2022 13:02:30+02:00"},"juju-status":{"current":"idle","since":"26 May 2022 13:02:32+02:00","version":"2.9.29"},"leader":false,"machine":"1","public-address":"10.246.154.111"}},"version":"20.04"}},"storage":{},"controller":{"timestamp":"13:03:13+02:00"}}"""  # noqa
 
 
 @pytest.fixture()
 def juju_status_mock():
-    with patch.object(juju, "status") as _status:
+    with patch.object(JujuSession, "status") as _status:
         _status().stdout = TEST_JUJU_STATUS_OUTPUT
         yield _status
 
@@ -37,3 +40,59 @@ def cluster_json():
     yield f.name
 
     f.close()
+
+
+@pytest.fixture()
+def collector_poll_period():
+    with patch.object(collector, "DEFAULT_POLL_PERIOD", new=0):
+        yield
+
+
+@pytest.fixture()
+def workload_time():
+    with patch.object(experiment, "WORKLOAD_TIME", new=1):
+        yield
+
+
+@pytest.fixture()
+def fetch_kubeconfig():
+    with patch(
+        "benchmarklib.experiment.Microk8sCluster.fetch_kubeconfig",
+        return_value="foobar",
+    ) as _fetch:
+        yield _fetch
+
+
+@pytest.fixture()
+def data_lake(temp_dir):
+    with patch(
+        "benchmarklib.experiment.DATA_LAKE_PATH",
+        new=Path(temp_dir),
+    ):
+        yield temp_dir
+
+
+@pytest.fixture()
+def all_nodes_joined_mock():
+    with patch("setup_cluster.JujuClusterSetup.all_nodes_joined", return_value=True):
+        yield
+
+
+@pytest.fixture()
+def setup_cluster_fixtures(
+    juju_status_mock, subprocess_run_mock, all_nodes_joined_mock
+):
+    yield
+
+
+@pytest.fixture()
+def scale_test_fixtures(
+    subprocess_run_mock,
+    workload_time,
+    cluster_json,
+    fetch_kubeconfig,
+    data_lake,
+    temp_dir,
+    collector_poll_period,
+):
+    yield

--- a/scripts/scale-test/tests/integration/test_scale_test_experiment.py
+++ b/scripts/scale-test/tests/integration/test_scale_test_experiment.py
@@ -1,49 +1,10 @@
 import sys
-from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 from scale_test import experiment
 
 
-@pytest.fixture()
-def workload_time():
-    with patch.object(experiment, "WORKLOAD_TIME", new=1):
-        yield
-
-
-@pytest.fixture()
-def fetch_kubeconfig():
-    with patch(
-        "benchmarklib.experiment.Microk8sCluster.fetch_kubeconfig",
-        return_value="foobar",
-    ) as _fetch:
-        yield _fetch
-
-
-@pytest.fixture()
-def data_lake(temp_dir):
-    with patch(
-        "benchmarklib.experiment.DATA_LAKE_PATH",
-        new=Path(temp_dir),
-    ):
-        yield temp_dir
-
-
-@pytest.fixture()
-def scale_test_mocks(
-    subprocess_run_mock,
-    workload_time,
-    cluster_json,
-    fetch_kubeconfig,
-    data_lake,
-    temp_dir,
-):
-    yield
-
-
-def test_main(scale_test_mocks, cluster_json):
+def test_main(scale_test_fixtures, cluster_json):
     with patch.object(sys, "argv", ["scale_testing", "-c", cluster_json]):
 
         experiment.main()

--- a/scripts/scale-test/tests/integration/test_setup_cluster.py
+++ b/scripts/scale-test/tests/integration/test_setup_cluster.py
@@ -1,22 +1,9 @@
 import sys
 from unittest.mock import patch
 
-import pytest
-
 import setup_cluster
 
 
-@pytest.fixture()
-def all_nodes_joined_mock():
-    with patch("setup_cluster.all_nodes_joined", return_value=True):
-        yield
-
-
-@pytest.fixture()
-def setup_cluster_mocks(juju_status_mock, subprocess_run_mock, all_nodes_joined_mock):
-    yield
-
-
 @patch.object(sys, "argv", ["setup_cluster", "--http-proxy", "http://myproxy"])
-def test_main(setup_cluster_mocks):
+def test_main(setup_cluster_fixtures):
     setup_cluster.main()


### PR DESCRIPTION
This PR refactors setup_cluster.py so that a JujuSession is used.

This will ease the benchmark logic - that needs to issue juju commands for different models simultaneously