### PR TITLE
Alleviate docker hub liimts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,5 @@ dmypy.json
 .tox_env
 
 # From scale-test
-.clusters/*
+.clusters/
+.docker_images/

--- a/scripts/scale-test/benchmarklib/clients/juju.py
+++ b/scripts/scale-test/benchmarklib/clients/juju.py
@@ -25,8 +25,8 @@ class JujuSession:
         self.model = model
         self.app = app
 
-    def run_in_unit(self, *command, unit: str):
-        return run(*command, unit=unit, model=self.model)
+    def run_in_unit(self, *command, unit: str, timeout: Optional[str] = None):
+        return run(*command, unit=unit, model=self.model, timeout=timeout)
 
     def run_in_units(self, *command, units: List[str], format=None):
         return run(*command, units=units, model=self.model, format=format)

--- a/scripts/scale-test/benchmarklib/cluster.py
+++ b/scripts/scale-test/benchmarklib/cluster.py
@@ -28,6 +28,14 @@ class Microk8sCluster:
         self.info = info
         self.juju = JujuSession(model=info.model, app=info.app)
 
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __str__(self):
+        return (
+            f"Microk8sCluster[model={self.info.model}][nodes={self.size}, cp={self.cp}]"
+        )
+
     @classmethod
     def from_file(klass, cluster_file: Path):
         with open(cluster_file, mode="r") as f:
@@ -37,6 +45,10 @@ class Microk8sCluster:
     @property
     def size(self) -> int:
         return len(self.info.control_plane) + len(self.info.workers)
+
+    @property
+    def cp(self) -> int:
+        return len(self.info.control_plane)
 
     def get_master_node(self) -> Unit:
         return self.info.master

--- a/scripts/scale-test/benchmarklib/constants.py
+++ b/scripts/scale-test/benchmarklib/constants.py
@@ -1,3 +1,15 @@
+from enum import Enum
+
 DEFAULT_ADD_NODE_TOKEN = "microk8sisgreatushouldgiveitatry"
 YEAR = 60 * 60 * 24 * 365
 DEFAULT_ADD_NODE_TOKEN_TTL = 5 * YEAR
+
+
+class KnownRegistries(Enum):
+    """
+    Known container registries
+    """
+
+    DOCKER = "docker.io"
+    QUAY = "quay.io"
+    K8S = "k8s.gcr.io"

--- a/scripts/scale-test/registry.py
+++ b/scripts/scale-test/registry.py
@@ -275,10 +275,6 @@ class RegistrySetup:
         self.run_in_unit(command)
 
 
-def setup_docker_registry(http_proxy: Optional[str] = None):
-    return RegistrySetup(http_proxy).setup()
-
-
 def push_images(images: DockerImages, registry_addr: Optional[str] = None):
     if registry_addr:
         pusher = LocalPusher(images, registry_addr)

--- a/scripts/scale-test/registry.py
+++ b/scripts/scale-test/registry.py
@@ -1,0 +1,362 @@
+#!/usr/bin/python
+
+import abc
+import argparse
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from benchmarklib.clients.juju import JujuSession
+from benchmarklib.cluster import Microk8sCluster
+from benchmarklib.constants import KnownRegistries
+from benchmarklib.models import Addon, Unit
+from setup_cluster import JujuClusterSetup, get_docker_credentials
+
+APP = "registry"
+MODEL = "registry"
+DEFAULT_UK8S_CHANNEL = "latest/edge"
+REGISTRY_PORT = 5000
+REGISTRY_UNIT_NAME = f"{APP}/0"
+
+DockerImages = Dict[str, str]
+
+DOCKER = "/usr/bin/docker"
+
+
+def _run_locally(*args):
+    cmd = []
+    for arg in args:
+        cmd.extend(arg.split())
+    logging.debug(f"subprocess.run {' '.join(cmd)}")
+    return subprocess.run(cmd, capture_output=True)
+
+
+class DockerImagePusher(metaclass=abc.ABCMeta):
+    def __init__(self, images: DockerImages):
+        self.images = images
+
+    def run_commands(self, commands: List[str]):
+        raise NotImplementedError()
+
+    @property
+    def registry_addr(self):
+        raise NotImplementedError()
+
+    def get_image_tag(self, image) -> str:
+        # replace registry domain part: docker.io/bar/foo:v1 --> localhost:5000/bar/foo:v1
+        for registry in KnownRegistries:
+            if image.startswith(registry.value):
+                image = image.replace(registry.value + "/", "")
+                break
+        return f"{self.registry_addr}/{image}"
+
+    def push(self):
+        logging.info("Pulling images...")
+        pull_commands = []
+        for image in self.images:
+            pull_commands.append(f"docker pull {image}")
+        self.run_commands(pull_commands)
+
+        logging.info("Tagging images...")
+        tag_commands = []
+        tags = []
+        for image in self.images:
+            tag = self.get_image_tag(image)
+            tags.append(tag)
+            tag_commands.append(f"docker tag {image} {tag}")
+        self.run_commands(tag_commands)
+
+        # Push them
+        logging.info("Pushing images...")
+        push_commands = []
+        for image_tag in tags:
+            push_commands.append(f"docker push {image_tag}")
+        self.run_commands(push_commands)
+
+
+class JujuPusher(DockerImagePusher):
+    """
+    Pushes docker images to registry via juju
+    """
+
+    def __init__(self, images: DockerImages):
+        super().__init__(images)
+        self.registry_unit = REGISTRY_UNIT_NAME
+        self.juju = JujuSession(MODEL, APP)
+
+    def run_commands(self, commands: List[str]):
+        juju_command = ";".join(commands)
+        self.juju.run_in_unit(*juju_command, unit=self.registry_unit).check_returncode()
+
+    @property
+    def registry_addr(self):
+        return "localhost:5000"
+
+
+class LocalPusher(DockerImagePusher):
+    """
+    Pushes docker images to registry via local docker CLI
+    """
+
+    def __init__(self, images: DockerImages, registry_addr: str):
+        super().__init__(images)
+        self.registry_addr = registry_addr
+
+    def run_commands(self, commands: List[str]):
+        for command in commands:
+            _run_locally(command).check_returncode()
+
+    @property
+    def registry_addr(self):
+        return self._registry_addr
+
+
+class ImageGetter:
+    """
+    Gets set of images to push to the registry.
+
+    It can read them from a previously saved json file under .docker_images/ or from a cluster.
+
+    It can also deploy a single-node microk8s cluster (with the specified channel) and
+    read the downloaded images.
+    """
+
+    def __init__(self):
+        self.images = None
+
+    def from_cluster(self, cluster: Microk8sCluster) -> DockerImages:
+        known_registries = [reg.value for reg in KnownRegistries]
+        command = "microk8s.ctr image ls -q"
+        resp = cluster.run_in_master_node(command)
+        to_parse = resp.stdout.decode()
+        images = []
+        for line in to_parse.splitlines():
+            if ":" not in line or "@sha" in line or line.startswith("sha256:"):
+                continue
+
+            registry_found = False
+            for registry in known_registries:
+                if line.startswith(registry):
+                    registry_found = True
+                    break
+
+            image = line.strip()
+            if not registry_found:
+                logging.warning(f"Image not expected: {line}. Skipping...")
+            else:
+                images.append(image)
+        self.images = images
+        return images
+
+    def from_file(self, path: Path) -> DockerImages:
+        with open(path, "r") as f:
+            self.images = json.loads(f.read())
+            return self.images
+
+    def save(self, name: str):
+        if self.images is None:
+            return
+
+        images_path = Path.cwd() / ".docker_images"
+        images_path.mkdir(parents=True, exist_ok=True)
+
+        name = name.replace("/", "-")
+        path = images_path / f"{name}.json"
+        logging.info(f"Saving images to {path}")
+        with open(path, "w") as f:
+            f.write(json.dumps(self.images))
+
+    def enable_addons_in_cluster(self, cluster):
+        """
+        We enable the most used addons so that container images are pulled
+        """
+        dns = Addon(name="dns")
+        hostpath = Addon(name="hostpath-storage", disable_arg="destroy-storage")
+        prometheus = Addon(name="prometheus")
+        all_addons = [
+            dns,
+            prometheus,
+            hostpath,
+        ]
+        cluster.enable([addon.enable for addon in all_addons])
+
+    def from_snap(self, channel: str, http_proxy: Optional[str] = None) -> DockerImages:
+        """
+        Setup a temporary microk8s single-node cluster with the specified
+        snap channel to dynamically get the list of images to push to the registry
+        """
+        mgr = JujuClusterSetup(
+            model="temp",
+            total_nodes=1,
+            control_plane_nodes=1,
+            channel=channel,
+            http_proxy=http_proxy,
+            creds=get_docker_credentials(),
+        )
+        with mgr.temporary_cluster() as cluster:
+            self.enable_addons_in_cluster(cluster)
+            self.images = self.from_cluster(cluster)
+            return self.images
+
+
+class RegistrySetup:
+    """
+    Class responsible for setting up a docker registry via juju.
+    """
+
+    def __init__(self, http_proxy: Optional[str] = None):
+        self.http_proxy = http_proxy
+        self.juju = JujuSession(MODEL, APP)
+        self.unit = None
+        self.registry_addr = None
+
+    def setup(self):
+        self.unit = self.deploy_unit()
+        if self.http_proxy:
+            self.configure_http_proxy(self.http_proxy)
+            self.reboot_and_wait()
+
+        logging.info(f"Juju unit for the registry: {self.unit}")
+        logging.warning("You will need to setup docker on it manually: ")
+        logging.warning(
+            f" - Ssh into it with: juju ssh -m {MODEL} -u {REGISTRY_UNIT_NAME}"
+        )
+        logging.warning(
+            " - Install Docker Engine following this guide: https://docs.docker.com/engine/install/ubuntu/"
+        )
+        logging.warning(
+            " - Start the registry following: https://docs.docker.com/registry/"
+        )
+
+    @property
+    def registry(self) -> str:
+        return self.unit.name
+
+    def run_in_unit(self, command):
+        self.juju.run_in_unit(command, unit=self.registry).check_returncode()
+
+    def deploy_unit(self) -> Unit:
+        logging.info("Deploying ubuntu unit")
+        self.juju.add_model().check_returncode()
+        self.juju.deploy("ubuntu", "--series=focal").check_returncode()
+        self.juju.wait_for_model()
+        return self.get_registry_unit()
+
+    def get_registry_unit(self) -> Unit:
+        return Unit(**(self.juju.get_units()[0]))
+
+    def reboot_and_wait(self):
+        """
+        Reboots all units in the model and then waits for them to be up.
+        """
+        logging.info("Rebooting all units")
+        self.juju.run_in_unit("reboot", unit=self.registry, timeout="10s")
+
+        logging.info("Waiting for model...")
+        self.juju.wait_for_model()
+
+    def configure_http_proxy(self, http_proxy: str):
+        logging.info("Configuring proxy settings")
+        command = ";".join(
+            [
+                f"echo HTTPS_PROXY={http_proxy} >> /etc/environment",
+                f"echo HTTP_PROXY={http_proxy} >> /etc/environment",
+                f"echo https_proxy={http_proxy} >> /etc/environment",
+                f"echo http_proxy={http_proxy} >> /etc/environment",
+                "local_ip=$(hostname -I | awk '{print $1}')",
+                "juju_instance_id=$(grep \"juju\" /etc/hosts | head -n 1 | awk '{print $NF}')",
+                'noproxy="10.0.0.0/8,localhost,127.0.0.1,${local_ip},${juju_instance_id}"',
+                "echo no_proxy=${noproxy} >> /etc/environment",
+                "echo NO_PROXY=${noproxy} >> /etc/environment",
+            ]
+        )
+        self.run_in_unit(command)
+
+
+def setup_docker_registry(http_proxy: Optional[str] = None):
+    return RegistrySetup(http_proxy).setup()
+
+
+def push_images(images: DockerImages, registry_addr: Optional[str] = None):
+    if registry_addr:
+        pusher = LocalPusher(images, registry_addr)
+    else:
+        pusher = JujuPusher(images)
+    pusher.push()
+
+
+def get_images_from_snap(channel: str, http_proxy: Optional[str] = None):
+    img_getter = ImageGetter()
+    images = img_getter.from_snap(channel, http_proxy)
+    img_getter.save(name=channel)
+    return images
+
+
+def get_images_from_file(imagesfile):
+    return ImageGetter().from_file(imagesfile)
+
+
+def get_images_from_cluster(clusterfile):
+    cluster = Microk8sCluster.from_file(clusterfile)
+    img_getter = ImageGetter()
+    images = img_getter.from_cluster(cluster)
+    cluster_name = clusterfile.split("/")[-1].split(".")[0]
+    img_getter.save(name=cluster_name)
+    return images
+
+
+def parse_arguments():
+    # create the top-level parser
+    parser = argparse.ArgumentParser(prog="setup_registry")
+    parser.add_argument("--action", choices=["setup", "push"], required=True)
+    parser.add_argument("--file", type=str, help="Path to images file")
+    parser.add_argument("--cluster", type=str, help="Path to cluster file")
+    parser.add_argument("-l", "--run-locally", action="store_true", default=False)
+    parser.add_argument("-r", "--registry", type=str)
+    parser.add_argument(
+        "--http-proxy", type=str, help="HTTP proxy to setup the units with"
+    )
+    parser.add_argument(
+        "--channel",
+        default=DEFAULT_UK8S_CHANNEL,
+        type=str,
+        help="Microk8s channel from which to download the images",
+    )
+    return parser.parse_args()
+
+
+def _validate_push_args(args):
+    required_args = [args.file, args.cluster, args.channel]
+    if not any(required_args) or all(required_args):
+        raise ValueError(
+            "Need to specify either --file, --channel or --cluster arguments"
+        )
+    if args.run_locally and args.registry is None:
+        raise ValueError("Need to speficy --registry (eg: http://10.248.168.29:5000)")
+
+
+def main():
+    args = parse_arguments()
+
+    if args.action == "push":
+        _validate_push_args(args)
+
+        # Get list of images to push
+        if args.file:
+            images = get_images_from_file(args.file)
+        elif args.cluster:
+            images = get_images_from_cluster(args.cluster)
+        else:  # args.channel:
+            images = get_images_from_snap(args.channel, args.http_proxy)
+
+        # Push them to the registry
+        push_images(images, args.registry)
+
+    elif args.action == "setup":
+        setup_docker_registry(args.http_proxy)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scale-test/registry.py
+++ b/scripts/scale-test/registry.py
@@ -102,7 +102,7 @@ class LocalPusher(DockerImagePusher):
 
     def __init__(self, images: DockerImages, registry_addr: str):
         super().__init__(images)
-        self.registry_addr = registry_addr
+        self._registry_addr = registry_addr.lstrip("http://")
 
     def run_commands(self, commands: List[str]):
         for command in commands:
@@ -362,8 +362,13 @@ def setup_docker_registry(args):
     RegistrySetup(args.http_proxy).setup()
 
 
+def configure_logging():
+    logging.root.setLevel(logging.DEBUG)
+
+
 def main():
     args = parse_arguments()
+    configure_logging()
     args.handler(args)
 
 

--- a/scripts/scale-test/setup-vsphere.sh
+++ b/scripts/scale-test/setup-vsphere.sh
@@ -27,7 +27,7 @@ sudo snap install juju  --classic
 sudo snap install juju-wait --classic
 
 echo "Adding vSphere cloud"
-echo >>vs.yaml "clouds:
+echo >> ~/vs.yaml "clouds:
    vsphere:
      type: vsphere
      auth-types: [userpass]
@@ -36,18 +36,18 @@ echo >>vs.yaml "clouds:
        Boston:
          endpoint: 10.246.152.100"
 juju add-cloud vsphere ~/vs.yaml
-rm vs.yaml
+rm ~/vs.yaml
 
 echo "Adding credential"
-echo > vs-cred.yaml "credentials:
+echo > ~/vs-cred.yaml "credentials:
     vsphere:
       k8s-crew:
         auth-type: userpass
         password: $vs_pass
         user: $vs_user
         vmfolder: k8s-crew-root"
-juju add-credential vsphere -f vs-cred.yaml --client
-rm vs-cred.yaml
+juju add-credential vsphere -f ~/vs-cred.yaml --client
+rm ~/vs-cred.yaml
 
 echo "Bootstrapping cloud..."
 juju bootstrap \

--- a/scripts/scale-test/setup_cluster.py
+++ b/scripts/scale-test/setup_cluster.py
@@ -126,9 +126,12 @@ class JujuClusterSetup:
 
         # [host."http://my.registry.internal:5000"]
         # capabilities = ["pull", "resolve"]
-        commands = []
-        hosts_file = f"/var/snap/microk8s/current/args/certs.d/{registry}/hosts.toml"
-        commands.append(f"rm -rf {hosts_file}")
+        registry_cert_dir = f"/var/snap/microk8s/current/args/certs.d/{registry}"
+        hosts_file = f"{registry_cert_dir}/hosts.toml"
+        commands = [
+            f"rm -rf {hosts_file}",
+            f"mkdir -p {registry_cert_dir}",
+        ]
         lines = [
             f'server = \\"{private_registry_addr}\\"',
             f'[host.\\"{private_registry_addr}\\"]',

--- a/scripts/scale-test/setup_cluster.py
+++ b/scripts/scale-test/setup_cluster.py
@@ -11,7 +11,11 @@ from typing import List, Optional
 
 from benchmarklib.clients.juju import JujuSession
 from benchmarklib.cluster import Microk8sCluster
-from benchmarklib.constants import DEFAULT_ADD_NODE_TOKEN, DEFAULT_ADD_NODE_TOKEN_TTL
+from benchmarklib.constants import (
+    DEFAULT_ADD_NODE_TOKEN,
+    DEFAULT_ADD_NODE_TOKEN_TTL,
+    KnownRegistries,
+)
 from benchmarklib.models import ClusterInfo, DockerCredentials, Unit
 from benchmarklib.utils import timeit
 
@@ -35,6 +39,7 @@ class JujuClusterSetup:
         channel: str,
         http_proxy: Optional[str] = None,
         creds: Optional[DockerCredentials] = None,
+        private_registry: Optional[str] = None,
         app: str = APP_NAME,
     ):
         self.app = app
@@ -45,6 +50,7 @@ class JujuClusterSetup:
         self.channel = channel
         self.http_proxy = http_proxy
         self.creds = creds
+        self.private_registry = private_registry
         self.units: List[Unit] = []
         self.cluster_info = None
 
@@ -53,6 +59,7 @@ class JujuClusterSetup:
         channel: str,
         http_proxy: Optional[str] = None,
         creds: Optional[DockerCredentials] = None,
+        private_registry: Optional[str] = None,
     ):
         """
         Installs microk8s snaps on all deployed units.
@@ -65,8 +72,8 @@ class JujuClusterSetup:
         self.install_snap(channel)
         self.update_etc_hosts()
 
-        if creds:
-            self.configure_containerd(creds)
+        if creds or private_registry:
+            self.configure_containerd(creds, private_registry)
 
         self.wait_microk8s_ready()
 
@@ -101,12 +108,40 @@ class JujuClusterSetup:
         cmd = "sudo snap restart microk8s.daemon-containerd"
         self.juju.run_in_all_units(cmd).check_returncode()
 
-    def configure_containerd(self, creds: DockerCredentials):
+    def configure_containerd(self, creds, registry_addr):
         """
         Configure docker credentials if specified.
         """
-        self.configure_containerd_credentials(creds)
-        self.restart_containerd()
+        if creds:
+            self.configure_containerd_credentials(creds)
+        if registry_addr:
+            self.configure_containerd_registries(registry_addr)
+        if creds or registry_addr:
+            self.restart_containerd()
+
+    def configure_containerd_mirror(self, registry, private_registry_addr):
+        logging.info(f"Configuring registry mirror for {registry}")
+        # # /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml
+        # server = "http://my.registry.internal:5000"
+
+        # [host."http://my.registry.internal:5000"]
+        # capabilities = ["pull", "resolve"]
+        commands = []
+        hosts_file = f"/var/snap/microk8s/current/args/certs.d/{registry}/hosts.toml"
+        commands.append(f"rm -rf {hosts_file}")
+        lines = [
+            f'server = \\"{private_registry_addr}\\"',
+            f'[host.\\"{private_registry_addr}\\"]',
+            'capabilities = [\\"pull\\", \\"resolve\\"]',
+        ]
+        for line in lines:
+            commands.append(f'echo "{line}" >> {hosts_file}')
+        cmd = ";".join(commands)
+        self.juju.run_in_all_units(cmd).check_returncode()
+
+    def configure_containerd_registries(self, private_registry_addr: str):
+        for registry in KnownRegistries:
+            self.configure_containerd_mirror(registry.value, private_registry_addr)
 
     def configure_containerd_credentials(self, creds: DockerCredentials):
         logging.info("Configuring containerd docker credentials")
@@ -309,6 +344,7 @@ class JujuClusterSetup:
             channel=self.channel,
             http_proxy=self.http_proxy,
             creds=self.creds,
+            private_registry=self.private_registry,
         )
         cluster_info = self.form_cluster(self.control_plane_nodes)
         self.save_cluster_info(cluster_info)
@@ -392,6 +428,12 @@ def parse_arguments() -> Namespace:
         type=str,
         help="Docker password to configure containerd with",
     )
+    parser.add_argument(
+        "--private-registry",
+        type=str,
+        default=None,
+        help="Address of the private docker registry in the form of {scheme}://{ip}:{port}",
+    )
     args = parser.parse_args()
     if args.control_plane > args.nodes:
         raise ValueError("--nodes >= --control-plane")
@@ -417,6 +459,7 @@ def main():
             channel=args.channel,
             http_proxy=args.http_proxy,
             creds=get_docker_credentials(args),
+            private_registry=args.private_registry,
         )
         mgr.setup()
     except KeyboardInterrupt:

--- a/scripts/scale-test/tests/integration/test_setup_registry.py
+++ b/scripts/scale-test/tests/integration/test_setup_registry.py
@@ -9,10 +9,7 @@ import registry
     "argv",
     [
         "setup_registry",
-        "--action",
         "setup",
-        "--channel",
-        "latest/edge",
         "--http-proxy",
         "http://myproxy",
     ],
@@ -25,6 +22,6 @@ def test_main_push(setup_registry_fixtures, docker_images_json):
     with patch.object(
         sys,
         "argv",
-        ["setup_registry", "--action", "push", "--file", docker_images_json],
+        ["setup_registry", "push", "--file", docker_images_json],
     ):
         registry.main()

--- a/scripts/scale-test/tests/integration/test_setup_registry.py
+++ b/scripts/scale-test/tests/integration/test_setup_registry.py
@@ -1,0 +1,30 @@
+import sys
+from unittest.mock import patch
+
+import registry
+
+
+@patch.object(
+    sys,
+    "argv",
+    [
+        "setup_registry",
+        "--action",
+        "setup",
+        "--channel",
+        "latest/edge",
+        "--http-proxy",
+        "http://myproxy",
+    ],
+)
+def test_main_setup(setup_registry_fixtures):
+    registry.main()
+
+
+def test_main_push(setup_registry_fixtures, docker_images_json):
+    with patch.object(
+        sys,
+        "argv",
+        ["setup_registry", "--action", "push", "--file", docker_images_json],
+    ):
+        registry.main()

--- a/scripts/scale-test/tests/unit/test_setup_cluster.py
+++ b/scripts/scale-test/tests/unit/test_setup_cluster.py
@@ -184,7 +184,7 @@ def test_install_microk8s_configures_containerd_iif_provided(
 
     mgr.install_microk8s(units, creds=creds)
 
-    mgr.configure_containerd.assert_called_once_with(creds)
+    mgr.configure_containerd.assert_called_once_with(creds, None)
 
 
 @patch("setup_cluster.JujuClusterSetup.wait_microk8s_ready")

--- a/scripts/scale-test/tox.ini
+++ b/scripts/scale-test/tox.ini
@@ -11,8 +11,9 @@ envdir = {toxinidir}/.tox_env
 benchmarklib_path = {toxinidir}/benchmarklib/
 scale_test_path = {toxinidir}/scale_test/
 setup_cluster_path = {toxinidir}/setup_cluster.py
+setup_registry_path = {toxinidir}/registry.py
 tests_path = {toxinidir}/tests/
-all_path = {[vars]benchmarklib_path} {[vars]scale_test_path} {[vars]setup_cluster_path} {[vars]tests_path}
+all_path = {[vars]benchmarklib_path} {[vars]scale_test_path} {[vars]setup_cluster_path} {[vars]tests_path} {[vars]setup_registry_path}
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
# PR Description
This PR attempts to alleviate the docker hub limit errors by setting up a docker registry in vsphere.

### Setting up a registry

You can setup a VM for the registry with the `setup` subcommand:
```
python registry.py setup --http-proxy=http://squid.internal:3128
```
It will spin up a ubuntu unit via juju in a new model named `registry`. However, due to a juju cli limitation, you will have to manually ssh into the VM, install the docker engine and start the registry container.

### Pushing images to the registry

The `push` subcommand facilitates pushing a set of container images to the registry.

You can do so by specific microk8s snap channel into the registry:
```
python registry.py push --channel latest/edge
```
This will setup a temporary microk8s cluster via juju, install the specified microk8s channel, collect the container images and push them to the registry.

Note that it will store the collected images in a json file under `.docker_images/latest-edge.json` so that you can push them again later with:
```
python registry.py push --file .docker_images/latest-edge.json
```

Finally, you can also download and push the images from an already existing cluster that has been setup with `setup_cluster.py` by specifying the cluster file:
```
python registry.py push --cluster .clusters/mycluster.json
```